### PR TITLE
Fix warnings on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 x64/
 fperf.*
 libz3.dll
+.DS_Store

--- a/lib/qms/switch_xbar_qm.hpp
+++ b/lib/qms/switch_xbar_qm.hpp
@@ -74,7 +74,6 @@ private:
 class ReducedLeafXBarQM : public SwitchXBarQM {
 public:
     ReducedLeafXBarQM(cid_t id,
-                      unsigned int leaf_id,
                       unsigned int starting_qid,
                       unsigned int servers_per_leaf,
                       unsigned int spine_cnt,
@@ -88,7 +87,6 @@ public:
     void add_constrs(NetContext& net_ctx, map<string, expr>& constr_map);
 
 private:
-    unsigned int leaf_id;
     unsigned int starting_qid;
     unsigned int servers_per_leaf;
     unsigned int spine_cnt;

--- a/lib/spec_factory.hpp
+++ b/lib/spec_factory.hpp
@@ -80,7 +80,6 @@ public:
 private:
     void initializeSpecs();
 
-    SharedConfig* shared_config = NULL;
     unsigned int total_time;
     unsigned int in_queue_cnt;
     qset_t target_queues;

--- a/lib/util.hpp
+++ b/lib/util.hpp
@@ -89,7 +89,7 @@ string banner(string b);
 
 template <typename... Args> string format_string(const string& format, Args... args) {
     char vname[100];
-    snprintf(vname,100, format.c_str(), args...);
+    snprintf(vname, 100, format.c_str(), args...);
     string s(vname);
     return s;
 }

--- a/lib/util.hpp
+++ b/lib/util.hpp
@@ -89,7 +89,7 @@ string banner(string b);
 
 template <typename... Args> string format_string(const string& format, Args... args) {
     char vname[100];
-    snprintf(vname, 100, format.c_str(), args...);
+    snprintf(vname,100, format.c_str(), args...);
     string s(vname);
     return s;
 }

--- a/lib/workload.hpp
+++ b/lib/workload.hpp
@@ -163,6 +163,7 @@ public:
     friend ostream& operator<<(ostream& os, const WlSpec* wl_spec);
     virtual bool operator==(const WlSpec& other) const = 0;
     bool operator<(const WlSpec& other) const;
+    virtual ~WlSpec() = default;
 
 protected:
     virtual string to_string() const = 0;

--- a/scripts/perf.sh
+++ b/scripts/perf.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+TEST_NAME=$1
+FPERF_PATH="../build/fperf"
+
+function cleanup() {
+  pkill -f fperf
+}
+
+function get_random() {
+  RESULT=$RANDOM
+  while awk '{print $2}' < rands.log | grep -q "$RESULT"; do
+    RESULT=$RANDOM
+  done
+  echo $RESULT
+}
+
+function get_best_time() {
+  tail -n 1 seeds.log | awk '{print $1}'
+#  awk '{if ($1) print $1}' < "seeds.log" | sort -n | head -1
+}
+
+
+function main() {
+  truncate -s 0 output.log
+
+  for i in $(seq 1 6); do
+    RAND="$(get_random)"
+    echo "$RAND" >> rands.log
+    $FPERF_PATH "$TEST_NAME" "$RAND"  >> output.log &
+  done
+
+  ELAPSED_TIME=0
+
+  while [ true ]; do
+      echo "Elapsed Time: $ELAPSED_TIME"
+      if [ -n "$(get_best_time)" ] && [ "$ELAPSED_TIME" -gt "$(get_best_time)" ]; then
+        echo "Elapsed Time exceeded best time, skipping this round"
+        break;
+      fi
+      if grep -q "FINISHED" "output.log"; then
+        echo "Found finished process"
+        BEST_SEED=$(awk '/FINISHED/{print $2}' < output.log | tail -n 1)
+        echo "$ELAPSED_TIME $BEST_SEED" >> seeds.log
+        break
+      fi
+      sleep 1
+      ELAPSED_TIME=$(( $ELAPSED_TIME + 1))
+  done
+
+  cleanup
+}
+
+main

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+TEST_NAME=$1
+
+trap 'pkill -f fperf; exit;' SIGINT SIGTERM
+
+for i in $(seq 1 1000); do
+    echo "Round: $i"
+    ./perf.sh $TEST_NAME
+    echo "----------------------"
+done
+
+

--- a/src/contention_point.cpp
+++ b/src/contention_point.cpp
@@ -273,7 +273,7 @@ void ContentionPoint::add_out_queue_constrs() {
                                           queue->deq_cnt(t) == (int) deq_bound));
 
             expr constr = mk_and(deq_cnt_vec);
-            snprintf(constr_name,100, "%s_deq_cnt_at_%d", queue->get_id().c_str(), t);
+            snprintf(constr_name, 100, "%s_deq_cnt_at_%d", queue->get_id().c_str(), t);
             add_constr(constr, constr_name);
             constr_map.insert(named_constr(constr_name, constr));
         }
@@ -535,7 +535,7 @@ bool ContentionPoint::generate_base_example(IndexedExample* base_eg,
     // Ensure there is a cap on the number of
     // empty queues to avoid trivial examples
     expr constr_expr = sum(empty_queues_expr_vec) <= (int) max_empty_queue;
-    snprintf(constr_name,100, "at_most_%d_empty_queues", max_empty_queue);
+    snprintf(constr_name, 100, "at_most_%d_empty_queues", max_empty_queue);
     z3_optimizer->add(constr_expr, constr_name);
 
     // First, maximize the total number of queues
@@ -615,7 +615,7 @@ void ContentionPoint::generate_good_examples(IndexedExample* base_eg,
 
         Metric* cenq_metric = in_queues[q]->get_metric(metric_t::CENQ);
         for (unsigned int t = 0; t < total_time; t++) {
-            snprintf(constr_name,100, "%d_is_zerod_queue[%d}", q, t);
+            snprintf(constr_name, 100, "%d_is_zerod_queue[%d}", q, t);
             expr constr_expr = cenq_metric->val(t).second == 0;
             z3_optimizer->add(constr_expr, constr_name);
         }
@@ -629,7 +629,7 @@ void ContentionPoint::generate_good_examples(IndexedExample* base_eg,
     // second to last time step (TODO: the exact constant
     // may need to be generalized.
     for (unsigned int q = 0; q < in_queues.size(); q++) {
-        snprintf(constr_name,100, "%d_example_trimming", q);
+        snprintf(constr_name, 100, "%d_example_trimming", q);
         expr constr_expr = in_queues[q]->enq_cnt(total_time - 1) == 0 &&
                            in_queues[q]->enq_cnt(total_time - 2) <= 1;
         z3_optimizer->add(constr_expr, constr_name);
@@ -695,7 +695,7 @@ void ContentionPoint::generate_good_examples(IndexedExample* base_eg,
                     // POP
                     z3_optimizer->pop();
                     // Make sure we don't get this example again
-                    snprintf(constr_name,100, "example_%d", i);
+                    snprintf(constr_name, 100, "example_%d", i);
                     z3_optimizer->add(not_this_example, constr_name);
 
 
@@ -743,7 +743,7 @@ void ContentionPoint::generate_bad_examples(unsigned int count, deque<IndexedExa
         if (target_queues.find(q) == target_queues.end()) {
             Metric* cenq_metric = in_queues[q]->get_metric(metric_t::CENQ);
             for (unsigned int t = 0; t < total_time; t++) {
-                snprintf(constr_name,100, "%d_is_zerod_queue[%d}", q, t);
+                snprintf(constr_name, 100, "%d_is_zerod_queue[%d}", q, t);
                 expr constr_expr = cenq_metric->val(t).second == 0;
                 z3_solver->add(constr_expr, constr_name);
             }
@@ -832,7 +832,7 @@ void ContentionPoint::generate_bad_examples(unsigned int count, deque<IndexedExa
                     z3_solver->pop();
 
                     // Make sure we don't get this example again
-                    snprintf(constr_name,100, "example_%d", i);
+                    snprintf(constr_name, 100, "example_%d", i);
                     z3_solver->add(not_this_example, constr_name);
 
 
@@ -870,7 +870,7 @@ void ContentionPoint::generate_good_examples_from_base_flow(deque<IndexedExample
         if (non_zero_queues.find(q) != non_zero_queues.end()) continue;
         Metric* cenq_metric = in_queues[q]->get_metric(metric_t::CENQ);
         for (unsigned int t = 0; t < total_time; t++) {
-            snprintf(constr_name,100, "%d_is_zerod_queue[%d}", q, t);
+            snprintf(constr_name, 100, "%d_is_zerod_queue[%d}", q, t);
             expr constr_expr = cenq_metric->val(t).second == 0;
             z3_optimizer->add(constr_expr, constr_name);
         }
@@ -879,7 +879,7 @@ void ContentionPoint::generate_good_examples_from_base_flow(deque<IndexedExample
 
     for (qset_t::iterator it = non_zero_queues.begin(); it != non_zero_queues.end(); it++) {
         unsigned int q = *it;
-        snprintf(constr_name,100, "%d_example_trimming", q);
+        snprintf(constr_name, 100, "%d_example_trimming", q);
         expr constr_expr = in_queues[q]->enq_cnt(total_time - 1) == 0 &&
                            in_queues[q]->enq_cnt(total_time - 2) <= 1;
         z3_optimizer->add(constr_expr, constr_name);
@@ -989,7 +989,7 @@ void ContentionPoint::generate_good_examples_from_base_flow(deque<IndexedExample
                     eg = new_eg;
 
                     z3_optimizer->pop();
-                    snprintf(constr_name,100, "example_%d", i);
+                    snprintf(constr_name, 100, "example_%d", i);
                     z3_optimizer->add(not_this_example, constr_name);
 
                     past_thresh.push_back(j);
@@ -1149,7 +1149,7 @@ void ContentionPoint::generate_good_examples_flow(deque<IndexedExample*>& exampl
         unsigned int queue = *it;
         Metric* cenq_metric = in_queues[queue]->get_metric(metric_t::CENQ);
         for (unsigned int t = 0; t < total_time; t++) {
-            snprintf(constr_name,100, "%d_is_zerod_queue[%d}", queue, t);
+            snprintf(constr_name, 100, "%d_is_zerod_queue[%d}", queue, t);
             expr constr_expr = cenq_metric->val(t).second == 0;
             z3_optimizer->add(constr_expr, constr_name);
         }
@@ -1157,7 +1157,7 @@ void ContentionPoint::generate_good_examples_flow(deque<IndexedExample*>& exampl
 
     for (qset_t::iterator it = target_queues.begin(); it != target_queues.end(); it++) {
         unsigned int q = *it;
-        snprintf(constr_name,100, "%d_example_trimming", q);
+        snprintf(constr_name, 100, "%d_example_trimming", q);
         expr constr_expr = in_queues[q]->enq_cnt(total_time - 1) == 0 &&
                            in_queues[q]->enq_cnt(total_time - 2) <= 1;
         z3_optimizer->add(constr_expr, constr_name);
@@ -1286,7 +1286,7 @@ void ContentionPoint::generate_good_examples_flow(deque<IndexedExample*>& exampl
                     eg = new_eg;
 
                     z3_optimizer->pop();
-                    snprintf(constr_name,100, "example_%d", i);
+                    snprintf(constr_name, 100, "example_%d", i);
                     z3_optimizer->add(not_this_example, constr_name);
 
                     past_thresh.push_back(j);
@@ -1342,7 +1342,7 @@ void ContentionPoint::generate_good_examples2(IndexedExample* base_eg,
 
         Metric* cenq_metric = in_queues[q]->get_metric(metric_t::CENQ);
         for (unsigned int t = 0; t < total_time; t++) {
-            snprintf(constr_name,100, "%d_is_zerod_queue[%d}", q, t);
+            snprintf(constr_name, 100, "%d_is_zerod_queue[%d}", q, t);
             expr constr_expr = cenq_metric->val(t).second == 0;
             z3_optimizer->add(constr_expr, constr_name);
         }
@@ -1356,7 +1356,7 @@ void ContentionPoint::generate_good_examples2(IndexedExample* base_eg,
     // second to last time step (TODO: the exact constant
     // may need to be generalized.
     for (unsigned int q = 0; q < in_queues.size(); q++) {
-        snprintf(constr_name,100, "%d_example_trimming", q);
+        snprintf(constr_name, 100, "%d_example_trimming", q);
         expr constr_expr = in_queues[q]->enq_cnt(total_time - 1) == 0 &&
                            in_queues[q]->enq_cnt(total_time - 2) <= 1;
         z3_optimizer->add(constr_expr, constr_name);
@@ -1469,7 +1469,7 @@ void ContentionPoint::generate_good_examples2(IndexedExample* base_eg,
                     eg = new_eg;
 
                     z3_optimizer->pop();
-                    snprintf(constr_name,100, "example_%d", i);
+                    snprintf(constr_name, 100, "example_%d", i);
                     z3_optimizer->add(not_this_example, constr_name);
 
                     past_thresh.push_back(j);

--- a/src/contention_point.cpp
+++ b/src/contention_point.cpp
@@ -273,7 +273,7 @@ void ContentionPoint::add_out_queue_constrs() {
                                           queue->deq_cnt(t) == (int) deq_bound));
 
             expr constr = mk_and(deq_cnt_vec);
-            snprintf(constr_name, 100, "%s_deq_cnt_at_%d", queue->get_id().c_str(), t);
+            snprintf(constr_name,100, "%s_deq_cnt_at_%d", queue->get_id().c_str(), t);
             add_constr(constr, constr_name);
             constr_map.insert(named_constr(constr_name, constr));
         }
@@ -535,7 +535,7 @@ bool ContentionPoint::generate_base_example(IndexedExample* base_eg,
     // Ensure there is a cap on the number of
     // empty queues to avoid trivial examples
     expr constr_expr = sum(empty_queues_expr_vec) <= (int) max_empty_queue;
-    snprintf(constr_name, 100, "at_most_%d_empty_queues", max_empty_queue);
+    snprintf(constr_name,100, "at_most_%d_empty_queues", max_empty_queue);
     z3_optimizer->add(constr_expr, constr_name);
 
     // First, maximize the total number of queues
@@ -615,7 +615,7 @@ void ContentionPoint::generate_good_examples(IndexedExample* base_eg,
 
         Metric* cenq_metric = in_queues[q]->get_metric(metric_t::CENQ);
         for (unsigned int t = 0; t < total_time; t++) {
-            snprintf(constr_name, 100, "%d_is_zerod_queue[%d}", q, t);
+            snprintf(constr_name,100, "%d_is_zerod_queue[%d}", q, t);
             expr constr_expr = cenq_metric->val(t).second == 0;
             z3_optimizer->add(constr_expr, constr_name);
         }
@@ -629,7 +629,7 @@ void ContentionPoint::generate_good_examples(IndexedExample* base_eg,
     // second to last time step (TODO: the exact constant
     // may need to be generalized.
     for (unsigned int q = 0; q < in_queues.size(); q++) {
-        snprintf(constr_name, 100, "%d_example_trimming", q);
+        snprintf(constr_name,100, "%d_example_trimming", q);
         expr constr_expr = in_queues[q]->enq_cnt(total_time - 1) == 0 &&
                            in_queues[q]->enq_cnt(total_time - 2) <= 1;
         z3_optimizer->add(constr_expr, constr_name);
@@ -695,7 +695,7 @@ void ContentionPoint::generate_good_examples(IndexedExample* base_eg,
                     // POP
                     z3_optimizer->pop();
                     // Make sure we don't get this example again
-                    snprintf(constr_name, 100, "example_%d", i);
+                    snprintf(constr_name,100, "example_%d", i);
                     z3_optimizer->add(not_this_example, constr_name);
 
 
@@ -743,7 +743,7 @@ void ContentionPoint::generate_bad_examples(unsigned int count, deque<IndexedExa
         if (target_queues.find(q) == target_queues.end()) {
             Metric* cenq_metric = in_queues[q]->get_metric(metric_t::CENQ);
             for (unsigned int t = 0; t < total_time; t++) {
-                snprintf(constr_name, 100, "%d_is_zerod_queue[%d}", q, t);
+                snprintf(constr_name,100, "%d_is_zerod_queue[%d}", q, t);
                 expr constr_expr = cenq_metric->val(t).second == 0;
                 z3_solver->add(constr_expr, constr_name);
             }
@@ -832,7 +832,7 @@ void ContentionPoint::generate_bad_examples(unsigned int count, deque<IndexedExa
                     z3_solver->pop();
 
                     // Make sure we don't get this example again
-                    snprintf(constr_name, 100, "example_%d", i);
+                    snprintf(constr_name,100, "example_%d", i);
                     z3_solver->add(not_this_example, constr_name);
 
 
@@ -870,7 +870,7 @@ void ContentionPoint::generate_good_examples_from_base_flow(deque<IndexedExample
         if (non_zero_queues.find(q) != non_zero_queues.end()) continue;
         Metric* cenq_metric = in_queues[q]->get_metric(metric_t::CENQ);
         for (unsigned int t = 0; t < total_time; t++) {
-            snprintf(constr_name, 100, "%d_is_zerod_queue[%d}", q, t);
+            snprintf(constr_name,100, "%d_is_zerod_queue[%d}", q, t);
             expr constr_expr = cenq_metric->val(t).second == 0;
             z3_optimizer->add(constr_expr, constr_name);
         }
@@ -879,7 +879,7 @@ void ContentionPoint::generate_good_examples_from_base_flow(deque<IndexedExample
 
     for (qset_t::iterator it = non_zero_queues.begin(); it != non_zero_queues.end(); it++) {
         unsigned int q = *it;
-        snprintf(constr_name, 100, "%d_example_trimming", q);
+        snprintf(constr_name,100, "%d_example_trimming", q);
         expr constr_expr = in_queues[q]->enq_cnt(total_time - 1) == 0 &&
                            in_queues[q]->enq_cnt(total_time - 2) <= 1;
         z3_optimizer->add(constr_expr, constr_name);
@@ -989,7 +989,7 @@ void ContentionPoint::generate_good_examples_from_base_flow(deque<IndexedExample
                     eg = new_eg;
 
                     z3_optimizer->pop();
-                    snprintf(constr_name, 100, "example_%d", i);
+                    snprintf(constr_name,100, "example_%d", i);
                     z3_optimizer->add(not_this_example, constr_name);
 
                     past_thresh.push_back(j);
@@ -1045,7 +1045,7 @@ void ContentionPoint::generate_good_examples_flow(deque<IndexedExample*>& exampl
         char constr_name[100];
         expr constr_expr = per_queue_enq_sum[q] >= min_cenq;
 
-        snprintf(constr_name, 100, "min_cenq_%d", q);
+        snprintf(constr_name,100, "min_cenq_%d", q);
         z3_optimizer->add(constr_expr, constr_name);
     }
     */
@@ -1149,7 +1149,7 @@ void ContentionPoint::generate_good_examples_flow(deque<IndexedExample*>& exampl
         unsigned int queue = *it;
         Metric* cenq_metric = in_queues[queue]->get_metric(metric_t::CENQ);
         for (unsigned int t = 0; t < total_time; t++) {
-            snprintf(constr_name, 100, "%d_is_zerod_queue[%d}", queue, t);
+            snprintf(constr_name,100, "%d_is_zerod_queue[%d}", queue, t);
             expr constr_expr = cenq_metric->val(t).second == 0;
             z3_optimizer->add(constr_expr, constr_name);
         }
@@ -1157,7 +1157,7 @@ void ContentionPoint::generate_good_examples_flow(deque<IndexedExample*>& exampl
 
     for (qset_t::iterator it = target_queues.begin(); it != target_queues.end(); it++) {
         unsigned int q = *it;
-        snprintf(constr_name, 100, "%d_example_trimming", q);
+        snprintf(constr_name,100, "%d_example_trimming", q);
         expr constr_expr = in_queues[q]->enq_cnt(total_time - 1) == 0 &&
                            in_queues[q]->enq_cnt(total_time - 2) <= 1;
         z3_optimizer->add(constr_expr, constr_name);
@@ -1169,7 +1169,7 @@ void ContentionPoint::generate_good_examples_flow(deque<IndexedExample*>& exampl
         unsigned int q = *it;
         for (unsigned int t = 0; t < total_time; t++){
             for (unsigned int p = 0; p < in_queues[q]->max_enq(); p++){
-                snprintf(constr_name, 100, "%d_test_%d_%d", q, t, p);
+                snprintf(constr_name,100, "%d_test_%d_%d", q, t, p);
                 expr pkt = in_queues[q]->enqs(p)[t];
                 expr constr_expr = implies(net_ctx.pkt2val(pkt),
                                            net_ctx.pkt2meta2(pkt) == 1);
@@ -1286,7 +1286,7 @@ void ContentionPoint::generate_good_examples_flow(deque<IndexedExample*>& exampl
                     eg = new_eg;
 
                     z3_optimizer->pop();
-                    snprintf(constr_name, 100, "example_%d", i);
+                    snprintf(constr_name,100, "example_%d", i);
                     z3_optimizer->add(not_this_example, constr_name);
 
                     past_thresh.push_back(j);
@@ -1342,7 +1342,7 @@ void ContentionPoint::generate_good_examples2(IndexedExample* base_eg,
 
         Metric* cenq_metric = in_queues[q]->get_metric(metric_t::CENQ);
         for (unsigned int t = 0; t < total_time; t++) {
-            snprintf(constr_name, 100, "%d_is_zerod_queue[%d}", q, t);
+            snprintf(constr_name,100, "%d_is_zerod_queue[%d}", q, t);
             expr constr_expr = cenq_metric->val(t).second == 0;
             z3_optimizer->add(constr_expr, constr_name);
         }
@@ -1356,7 +1356,7 @@ void ContentionPoint::generate_good_examples2(IndexedExample* base_eg,
     // second to last time step (TODO: the exact constant
     // may need to be generalized.
     for (unsigned int q = 0; q < in_queues.size(); q++) {
-        snprintf(constr_name, 100, "%d_example_trimming", q);
+        snprintf(constr_name,100, "%d_example_trimming", q);
         expr constr_expr = in_queues[q]->enq_cnt(total_time - 1) == 0 &&
                            in_queues[q]->enq_cnt(total_time - 2) <= 1;
         z3_optimizer->add(constr_expr, constr_name);
@@ -1469,7 +1469,7 @@ void ContentionPoint::generate_good_examples2(IndexedExample* base_eg,
                     eg = new_eg;
 
                     z3_optimizer->pop();
-                    snprintf(constr_name, 100, "example_%d", i);
+                    snprintf(constr_name,100, "example_%d", i);
                     z3_optimizer->add(not_this_example, constr_name);
 
                     past_thresh.push_back(j);

--- a/src/metrics/dst.cpp
+++ b/src/metrics/dst.cpp
@@ -23,7 +23,8 @@ void Dst::eval(const IndexedExample* eg, unsigned int time, unsigned int qind, m
 
     res.value = enqs_meta1[0];
     for (unsigned int i = 1; i < enqs_meta1.size(); i++) {
-        if (enqs_meta1[i] != res.value) {
+        // FIXME: change enqs_meta2 to unsigned int
+        if (enqs_meta1[i] != static_cast<int>(res.value)) {
             res.valid = false;
             return;
         }

--- a/src/metrics/ecmp.cpp
+++ b/src/metrics/ecmp.cpp
@@ -23,7 +23,8 @@ void Ecmp::eval(const IndexedExample* eg, unsigned int time, unsigned int qind, 
 
     res.value = enqs_meta2[0];
     for (unsigned int i = 1; i < enqs_meta2.size(); i++) {
-        if (enqs_meta2[i] != res.value) {
+        // FIXME: change enqs_meta2 to unsigned int
+        if (enqs_meta2[i] != static_cast<int>(res.value)) {
             res.valid = false;
             return;
         }

--- a/src/qms/buggy_2l_rr_qm.cpp
+++ b/src/qms/buggy_2l_rr_qm.cpp
@@ -29,7 +29,7 @@ void Buggy2LRRQM::add_proc_vars(NetContext& net_ctx) {
 
     for (unsigned int q = 0; q < in_queues.size(); q++) {
         for (unsigned int t = 0; t < total_time; t++) {
-            snprintf(vname,100, "%s_inactive[%d][%d]", id.c_str(), q, t);
+            snprintf(vname, 100, "%s_inactive[%d][%d]", id.c_str(), q, t);
             inactive_[q].push_back(net_ctx.bool_const(vname));
         }
     }
@@ -46,7 +46,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
 
     // Init for time zero
     for (unsigned int q = 0; q < in_queue_cnt; q++) {
-        snprintf(constr_name,100, "%s_%d_inactive_at_0", id.c_str(), q);
+        snprintf(constr_name, 100, "%s_%d_inactive_at_0", id.c_str(), q);
         expr constr_expr = inactive_[q][0];
         constr_map.insert(named_constr(constr_name, constr_expr));
     }
@@ -65,12 +65,12 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
                 Queue* queue = in_queues[q];
                 expr had_enq = net_ctx.pkt2val(queue->enqs(0)[prev_t]);
 
-                snprintf(constr_name,100, "%s_activate_%d_at_%d", id.c_str(), q, t);
+                snprintf(constr_name, 100, "%s_activate_%d_at_%d", id.c_str(), q, t);
                 expr constr_expr = implies(inactive_[q][prev_t] && had_enq, !inactive_[q][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
                 // keep inactive
-                snprintf(constr_name,100, "%s_keep_inactive_%d_at_%d", id.c_str(), q, t);
+                snprintf(constr_name, 100, "%s_keep_inactive_%d_at_%d", id.c_str(), q, t);
                 constr_expr = implies(inactive_[q][prev_t] && !had_enq, inactive_[q][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -90,7 +90,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
                     implies(prev_unavailable,
                             net_ctx.pkt2val(meta_pkt) && net_ctx.pkt2meta1(meta_pkt) == (int) q));
             }
-            snprintf(constr_name,100, "%s_insert_%d_into_new_at_%d", id.c_str(), q, t);
+            snprintf(constr_name, 100, "%s_insert_%d_into_new_at_%d", id.c_str(), q, t);
             expr constr_expr = implies(inactive_[q][t] && has_enq, mk_or(insert_vec));
             constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -104,12 +104,14 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
 
         // Don't allow extra random enqs
         for (unsigned int ind = 0; ind < in_queue_cnt; ind++) {
-            snprintf(constr_name,100, "%s_new_queues_enq_cnt_bounds1_%d_at_%d", id.c_str(), ind, t);
+            snprintf(
+                constr_name, 100, "%s_new_queues_enq_cnt_bounds1_%d_at_%d", id.c_str(), ind, t);
             expr constr_expr = implies(net_ctx.pkt2val(new_queues->enqs(ind)[t]),
                                        sum(activated_vec) > (int) ind);
             constr_map.insert(named_constr(constr_name, constr_expr));
 
-            snprintf(constr_name,100, "%s_new_queues_enq_cnt_bounds2_%d_at_%d", id.c_str(), ind, t);
+            snprintf(
+                constr_name, 100, "%s_new_queues_enq_cnt_bounds2_%d_at_%d", id.c_str(), ind, t);
             constr_expr = implies(sum(activated_vec) <= (int) ind,
                                   new_queues->enqs(ind)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -120,7 +122,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
             expr enq1_val = net_ctx.pkt2val(new_queues->enqs(ind)[t]);
             expr enq2_val = net_ctx.pkt2val(new_queues->enqs(ind + 1)[t]);
 
-            snprintf(constr_name,100, "%s_new_no_enq_holes_ind_%d_at_%d", id.c_str(), ind, t);
+            snprintf(constr_name, 100, "%s_new_no_enq_holes_ind_%d_at_%d", id.c_str(), ind, t);
             expr constr_expr = enq1_val || !enq2_val;
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -131,7 +133,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
                 expr pkt1 = new_queues->enqs(i)[t];
                 expr pkt2 = new_queues->enqs(j)[t];
 
-                snprintf(constr_name,100, "%s_new_%d_and_%d_unique_at_%d", id.c_str(), i, j, t);
+                snprintf(constr_name, 100, "%s_new_%d_and_%d_unique_at_%d", id.c_str(), i, j, t);
                 expr constr_expr = implies(net_ctx.pkt2val(pkt1) && net_ctx.pkt2val(pkt2),
                                            net_ctx.pkt2meta1(pkt1) != net_ctx.pkt2meta1(pkt2));
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -154,15 +156,15 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
             per_queue_expr = implies(deq_criteria, in_queues[q]->deq_cnt(t) == 1);
             get_from_new_queues.push_back(per_queue_expr);
         }
-        snprintf(constr_name,100, "%s_deq_from_new_queues_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_deq_from_new_queues_at_%d", id.c_str(), t);
         constr_map.insert(named_constr(constr_name, mk_and(get_from_new_queues)));
 
         // set deq_cnt for new queues
-        snprintf(constr_name,100, "%s_new_queues_deq_cnt_is_1_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_new_queues_deq_cnt_is_1_at_%d", id.c_str(), t);
         expr constr_expr = implies(net_ctx.pkt2val(new_queues_head), new_queues->deq_cnt(t) == 1);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        snprintf(constr_name,100, "%s_new_queues_deq_cnt_is_0_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_new_queues_deq_cnt_is_0_at_%d", id.c_str(), t);
         constr_expr = implies(!net_ctx.pkt2val(new_queues_head), new_queues->deq_cnt(t) == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -183,12 +185,12 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
 
             from_new_to_old.push_back(per_queue_expr);
         }
-        snprintf(constr_name,100, "%s_from_new_to_old_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_from_new_to_old_at_%d", id.c_str(), t);
         constr_expr = mk_and(from_new_to_old);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // No enqs into old queues
-        snprintf(constr_name,100, "%s_no_enqs_into_old_queues_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_no_enqs_into_old_queues_at_%d", id.c_str(), t);
         expr_vector new_head_queue_empty_vec(net_ctx.z3_ctx());
         for (unsigned int q = 0; q < in_queue_cnt; q++) {
             new_head_queue_empty_vec.push_back(net_ctx.pkt2meta1(new_queues_head) == (int) q &&
@@ -232,16 +234,16 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
             per_queue_expr = implies(deq_criteria, in_queues[q]->deq_cnt(t) == 1);
             get_from_old_queues.push_back(per_queue_expr);
         }
-        snprintf(constr_name,100, "%s_deq_from_old_queues_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_deq_from_old_queues_at_%d", id.c_str(), t);
         constr_map.insert(named_constr(constr_name, mk_and(get_from_old_queues)));
 
         // set deq_cnt for old queues
-        snprintf(constr_name,100, "%s_old_queues_deq_cnt_is_1_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_old_queues_deq_cnt_is_1_at_%d", id.c_str(), t);
         constr_expr = implies(!net_ctx.pkt2val(new_queues_head) && net_ctx.pkt2val(old_queues_head),
                               old_queues->deq_cnt(t) == 1);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        snprintf(constr_name,100, "%s_old_queues_deq_cnt_is_0_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_old_queues_deq_cnt_is_0_at_%d", id.c_str(), t);
         constr_expr = implies(net_ctx.pkt2val(new_queues_head) || !net_ctx.pkt2val(old_queues_head),
                               old_queues->deq_cnt(t) == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
@@ -263,7 +265,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
 
             from_old_to_old.push_back(per_queue_expr);
         }
-        snprintf(constr_name,100, "%s_from_old_to_old_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_from_old_to_old_at_%d", id.c_str(), t);
         constr_expr = mk_and(from_old_to_old);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -277,7 +279,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
                                          net_ctx.pkt2val(old_queues_head) &&
                                          net_ctx.pkt2meta1(old_queues_head) == (int) q;
 
-                snprintf(constr_name,100, "%s_%d_becomes_inactive_at_%d", id.c_str(), q, t + 1);
+                snprintf(constr_name, 100, "%s_%d_becomes_inactive_at_%d", id.c_str(), q, t + 1);
                 constr_expr = implies((dequeued_from_new || dequeued_from_old) &&
                                           !net_ctx.pkt2val(in_queues[q]->elem(1)[t]) &&
                                           !net_ctx.pkt2val(in_queues[q]->enqs(0)[t]),
@@ -316,12 +318,12 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
                                                   net_ctx.pkt2meta1(meta_pkt) == (int) q);
                 }
 
-                snprintf(constr_name,100, "%s_keep_%d_active1_at_%d", id.c_str(), q, t);
+                snprintf(constr_name, 100, "%s_keep_%d_active1_at_%d", id.c_str(), q, t);
                 constr_expr = implies(!inactive_[q][prev_t] && mk_or(somewhere_in_queues),
                                       !inactive_[q][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
-                snprintf(constr_name,100, "%s_keep_%d_active2_at_%d", id.c_str(), q, t);
+                snprintf(constr_name, 100, "%s_keep_%d_active2_at_%d", id.c_str(), q, t);
                 constr_expr = implies(net_ctx.pkt2val(new_queues->elem(0)[prev_t]) &&
                                           net_ctx.pkt2val(old_queues->elem(0)[prev_t]) &&
                                           net_ctx.pkt2meta1(old_queues->elem(0)[prev_t]) == (int) q,
@@ -342,7 +344,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
             expr not_chosen3 = !net_ctx.pkt2val(new_queues_head) &&
                                !net_ctx.pkt2val(old_queues_head);
 
-            snprintf(constr_name,100, "%s_deq_cnt_for_%d_is_0_at_%d", id.c_str(), q, t);
+            snprintf(constr_name, 100, "%s_deq_cnt_for_%d_is_0_at_%d", id.c_str(), q, t);
             constr_expr = implies(not_chosen1 || not_chosen2 || not_chosen3,
                                   in_queues[q]->deq_cnt(t) == 0);
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -353,13 +355,13 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
         for (unsigned int q = 0; q < in_queue_cnt; q++) {
             inactive_vec.push_back(inactive_[q][t]);
         }
-        snprintf(constr_name,100, "%s_if_all_inactive_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_if_all_inactive_at_%d", id.c_str(), t);
         constr_expr = implies(mk_and(inactive_vec), outq->enqs(0)[t] == net_ctx.null_pkt());
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // Make sure nothing else gets pushed to the output queue
         for (unsigned int i = 1; i < outq->max_enq(); i++) {
-            snprintf(constr_name,100, "%s_only_one_output_%d_%d", id.c_str(), i, t);
+            snprintf(constr_name, 100, "%s_only_one_output_%d_%d", id.c_str(), i, t);
             expr constr_expr = outq->enqs(i)[t] == net_ctx.null_pkt();
             constr_map.insert(named_constr(constr_name, constr_expr));
         }

--- a/src/qms/buggy_2l_rr_qm.cpp
+++ b/src/qms/buggy_2l_rr_qm.cpp
@@ -29,7 +29,7 @@ void Buggy2LRRQM::add_proc_vars(NetContext& net_ctx) {
 
     for (unsigned int q = 0; q < in_queues.size(); q++) {
         for (unsigned int t = 0; t < total_time; t++) {
-            sprintf(vname, "%s_inactive[%d][%d]", id.c_str(), q, t);
+            snprintf(vname,100, "%s_inactive[%d][%d]", id.c_str(), q, t);
             inactive_[q].push_back(net_ctx.bool_const(vname));
         }
     }
@@ -46,7 +46,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
 
     // Init for time zero
     for (unsigned int q = 0; q < in_queue_cnt; q++) {
-        sprintf(constr_name, "%s_%d_inactive_at_0", id.c_str(), q);
+        snprintf(constr_name,100, "%s_%d_inactive_at_0", id.c_str(), q);
         expr constr_expr = inactive_[q][0];
         constr_map.insert(named_constr(constr_name, constr_expr));
     }
@@ -65,12 +65,12 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
                 Queue* queue = in_queues[q];
                 expr had_enq = net_ctx.pkt2val(queue->enqs(0)[prev_t]);
 
-                sprintf(constr_name, "%s_activate_%d_at_%d", id.c_str(), q, t);
+                snprintf(constr_name,100, "%s_activate_%d_at_%d", id.c_str(), q, t);
                 expr constr_expr = implies(inactive_[q][prev_t] && had_enq, !inactive_[q][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
                 // keep inactive
-                sprintf(constr_name, "%s_keep_inactive_%d_at_%d", id.c_str(), q, t);
+                snprintf(constr_name,100, "%s_keep_inactive_%d_at_%d", id.c_str(), q, t);
                 constr_expr = implies(inactive_[q][prev_t] && !had_enq, inactive_[q][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -90,7 +90,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
                     implies(prev_unavailable,
                             net_ctx.pkt2val(meta_pkt) && net_ctx.pkt2meta1(meta_pkt) == (int) q));
             }
-            sprintf(constr_name, "%s_insert_%d_into_new_at_%d", id.c_str(), q, t);
+            snprintf(constr_name,100, "%s_insert_%d_into_new_at_%d", id.c_str(), q, t);
             expr constr_expr = implies(inactive_[q][t] && has_enq, mk_or(insert_vec));
             constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -104,12 +104,12 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
 
         // Don't allow extra random enqs
         for (unsigned int ind = 0; ind < in_queue_cnt; ind++) {
-            sprintf(constr_name, "%s_new_queues_enq_cnt_bounds1_%d_at_%d", id.c_str(), ind, t);
+            snprintf(constr_name,100, "%s_new_queues_enq_cnt_bounds1_%d_at_%d", id.c_str(), ind, t);
             expr constr_expr = implies(net_ctx.pkt2val(new_queues->enqs(ind)[t]),
                                        sum(activated_vec) > (int) ind);
             constr_map.insert(named_constr(constr_name, constr_expr));
 
-            sprintf(constr_name, "%s_new_queues_enq_cnt_bounds2_%d_at_%d", id.c_str(), ind, t);
+            snprintf(constr_name,100, "%s_new_queues_enq_cnt_bounds2_%d_at_%d", id.c_str(), ind, t);
             constr_expr = implies(sum(activated_vec) <= (int) ind,
                                   new_queues->enqs(ind)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -120,7 +120,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
             expr enq1_val = net_ctx.pkt2val(new_queues->enqs(ind)[t]);
             expr enq2_val = net_ctx.pkt2val(new_queues->enqs(ind + 1)[t]);
 
-            sprintf(constr_name, "%s_new_no_enq_holes_ind_%d_at_%d", id.c_str(), ind, t);
+            snprintf(constr_name,100, "%s_new_no_enq_holes_ind_%d_at_%d", id.c_str(), ind, t);
             expr constr_expr = enq1_val || !enq2_val;
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -131,7 +131,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
                 expr pkt1 = new_queues->enqs(i)[t];
                 expr pkt2 = new_queues->enqs(j)[t];
 
-                sprintf(constr_name, "%s_new_%d_and_%d_unique_at_%d", id.c_str(), i, j, t);
+                snprintf(constr_name,100, "%s_new_%d_and_%d_unique_at_%d", id.c_str(), i, j, t);
                 expr constr_expr = implies(net_ctx.pkt2val(pkt1) && net_ctx.pkt2val(pkt2),
                                            net_ctx.pkt2meta1(pkt1) != net_ctx.pkt2meta1(pkt2));
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -154,15 +154,15 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
             per_queue_expr = implies(deq_criteria, in_queues[q]->deq_cnt(t) == 1);
             get_from_new_queues.push_back(per_queue_expr);
         }
-        sprintf(constr_name, "%s_deq_from_new_queues_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_deq_from_new_queues_at_%d", id.c_str(), t);
         constr_map.insert(named_constr(constr_name, mk_and(get_from_new_queues)));
 
         // set deq_cnt for new queues
-        sprintf(constr_name, "%s_new_queues_deq_cnt_is_1_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_new_queues_deq_cnt_is_1_at_%d", id.c_str(), t);
         expr constr_expr = implies(net_ctx.pkt2val(new_queues_head), new_queues->deq_cnt(t) == 1);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        sprintf(constr_name, "%s_new_queues_deq_cnt_is_0_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_new_queues_deq_cnt_is_0_at_%d", id.c_str(), t);
         constr_expr = implies(!net_ctx.pkt2val(new_queues_head), new_queues->deq_cnt(t) == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -183,12 +183,12 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
 
             from_new_to_old.push_back(per_queue_expr);
         }
-        sprintf(constr_name, "%s_from_new_to_old_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_from_new_to_old_at_%d", id.c_str(), t);
         constr_expr = mk_and(from_new_to_old);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // No enqs into old queues
-        sprintf(constr_name, "%s_no_enqs_into_old_queues_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_no_enqs_into_old_queues_at_%d", id.c_str(), t);
         expr_vector new_head_queue_empty_vec(net_ctx.z3_ctx());
         for (unsigned int q = 0; q < in_queue_cnt; q++) {
             new_head_queue_empty_vec.push_back(net_ctx.pkt2meta1(new_queues_head) == (int) q &&
@@ -232,16 +232,16 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
             per_queue_expr = implies(deq_criteria, in_queues[q]->deq_cnt(t) == 1);
             get_from_old_queues.push_back(per_queue_expr);
         }
-        sprintf(constr_name, "%s_deq_from_old_queues_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_deq_from_old_queues_at_%d", id.c_str(), t);
         constr_map.insert(named_constr(constr_name, mk_and(get_from_old_queues)));
 
         // set deq_cnt for old queues
-        sprintf(constr_name, "%s_old_queues_deq_cnt_is_1_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_old_queues_deq_cnt_is_1_at_%d", id.c_str(), t);
         constr_expr = implies(!net_ctx.pkt2val(new_queues_head) && net_ctx.pkt2val(old_queues_head),
                               old_queues->deq_cnt(t) == 1);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        sprintf(constr_name, "%s_old_queues_deq_cnt_is_0_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_old_queues_deq_cnt_is_0_at_%d", id.c_str(), t);
         constr_expr = implies(net_ctx.pkt2val(new_queues_head) || !net_ctx.pkt2val(old_queues_head),
                               old_queues->deq_cnt(t) == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
@@ -263,7 +263,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
 
             from_old_to_old.push_back(per_queue_expr);
         }
-        sprintf(constr_name, "%s_from_old_to_old_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_from_old_to_old_at_%d", id.c_str(), t);
         constr_expr = mk_and(from_old_to_old);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -277,7 +277,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
                                          net_ctx.pkt2val(old_queues_head) &&
                                          net_ctx.pkt2meta1(old_queues_head) == (int) q;
 
-                sprintf(constr_name, "%s_%d_becomes_inactive_at_%d", id.c_str(), q, t + 1);
+                snprintf(constr_name,100, "%s_%d_becomes_inactive_at_%d", id.c_str(), q, t + 1);
                 constr_expr = implies((dequeued_from_new || dequeued_from_old) &&
                                           !net_ctx.pkt2val(in_queues[q]->elem(1)[t]) &&
                                           !net_ctx.pkt2val(in_queues[q]->enqs(0)[t]),
@@ -316,12 +316,12 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
                                                   net_ctx.pkt2meta1(meta_pkt) == (int) q);
                 }
 
-                sprintf(constr_name, "%s_keep_%d_active1_at_%d", id.c_str(), q, t);
+                snprintf(constr_name,100, "%s_keep_%d_active1_at_%d", id.c_str(), q, t);
                 constr_expr = implies(!inactive_[q][prev_t] && mk_or(somewhere_in_queues),
                                       !inactive_[q][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
-                sprintf(constr_name, "%s_keep_%d_active2_at_%d", id.c_str(), q, t);
+                snprintf(constr_name,100, "%s_keep_%d_active2_at_%d", id.c_str(), q, t);
                 constr_expr = implies(net_ctx.pkt2val(new_queues->elem(0)[prev_t]) &&
                                           net_ctx.pkt2val(old_queues->elem(0)[prev_t]) &&
                                           net_ctx.pkt2meta1(old_queues->elem(0)[prev_t]) == (int) q,
@@ -342,7 +342,7 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
             expr not_chosen3 = !net_ctx.pkt2val(new_queues_head) &&
                                !net_ctx.pkt2val(old_queues_head);
 
-            sprintf(constr_name, "%s_deq_cnt_for_%d_is_0_at_%d", id.c_str(), q, t);
+            snprintf(constr_name,100, "%s_deq_cnt_for_%d_is_0_at_%d", id.c_str(), q, t);
             constr_expr = implies(not_chosen1 || not_chosen2 || not_chosen3,
                                   in_queues[q]->deq_cnt(t) == 0);
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -353,13 +353,13 @@ void Buggy2LRRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
         for (unsigned int q = 0; q < in_queue_cnt; q++) {
             inactive_vec.push_back(inactive_[q][t]);
         }
-        sprintf(constr_name, "%s_if_all_inactive_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_if_all_inactive_at_%d", id.c_str(), t);
         constr_expr = implies(mk_and(inactive_vec), outq->enqs(0)[t] == net_ctx.null_pkt());
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // Make sure nothing else gets pushed to the output queue
         for (unsigned int i = 1; i < outq->max_enq(); i++) {
-            sprintf(constr_name, "%s_only_one_output_%d_%d", id.c_str(), i, t);
+            snprintf(constr_name,100, "%s_only_one_output_%d_%d", id.c_str(), i, t);
             expr constr_expr = outq->enqs(i)[t] == net_ctx.null_pkt();
             constr_map.insert(named_constr(constr_name, constr_expr));
         }

--- a/src/qms/leaf_forwarding_qm.cpp
+++ b/src/qms/leaf_forwarding_qm.cpp
@@ -47,7 +47,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
         expr dst_spine = net_ctx.pkt2meta2(in_pkt);
 
         // Set deq_cnt for input queue
-        sprintf(constr_name, "%s_in_queue_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_in_queue_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
         expr constr_expr = implies(pkt_val, in_queue->deq_cnt(t) == 1) &&
                            implies(!pkt_val, in_queue->deq_cnt(t) == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
@@ -62,7 +62,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
             if (output_voq_map.find(dst_port) == output_voq_map.end()) continue;
 
             unsigned int dst_queue = output_voq_map[dst_port];
-            sprintf(constr_name, "%s_forward_dst_%d_to_port%d(q%d)_at_%d", id.c_str(), dst,
+            snprintf(constr_name,100, "%s_forward_dst_%d_to_port%d(q%d)_at_%d", id.c_str(), dst,
         dst_port, dst_queue, t); constr_expr = implies(pkt_val && pkt_dst == (int) dst,
                                   out_queues[dst_queue]->enqs(0)[t] == in_pkt);
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -79,12 +79,12 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 if (output_voq_map.find(dst_port) == output_voq_map.end()) continue;
                 unsigned int voq_ind = output_voq_map[dst_port];
 
-                sprintf(constr_name, "%s_forward_spine_%d_at_%d", id.c_str(), s, t);
+                snprintf(constr_name,100, "%s_forward_spine_%d_at_%d", id.c_str(), s, t);
                 constr_expr = implies(pkt_val && dst_outside && dst_spine == (int) s,
                                       out_queues[voq_ind]->enqs(0)[t] == in_pkt);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
-                sprintf(constr_name, "%s_dont_forward_spine_%d_at_%d", id.c_str(), s, t);
+                snprintf(constr_name,100, "%s_dont_forward_spine_%d_at_%d", id.c_str(), s, t);
 
                 constr_expr = implies(!dst_outside || dst_spine != (int) s,
                                       out_queues[voq_ind]->enqs(0)[t] == net_ctx.null_pkt());
@@ -99,12 +99,12 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
             if (output_voq_map.find(dst_port) == output_voq_map.end()) continue;
 
             unsigned int voq_ind = output_voq_map[dst_port];
-            sprintf(constr_name, "%s_forward_dst_%d_at_%d", id.c_str(), dst, t);
+            snprintf(constr_name,100, "%s_forward_dst_%d_at_%d", id.c_str(), dst, t);
             constr_expr = implies(pkt_val && pkt_dst == (int) dst,
                                   out_queues[voq_ind]->enqs(0)[t] == in_pkt);
             constr_map.insert(named_constr(constr_name, constr_expr));
 
-            sprintf(constr_name, "%s_dont_forward_dst_%d_at_%d", id.c_str(), dst, t);
+            snprintf(constr_name,100, "%s_dont_forward_dst_%d_at_%d", id.c_str(), dst, t);
             constr_expr = implies(pkt_dst != (int) dst,
                                   out_queues[voq_ind]->enqs(0)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -115,7 +115,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
             if (output_voq_map.find(i) == output_voq_map.end()) continue;
 
             unsigned int voq_ind = output_voq_map[i];
-            sprintf(constr_name, "%s_no_match_port%d(q%d)_at_%d", id.c_str(), i, voq_ind, t);
+            snprintf(constr_name,100, "%s_no_match_port%d(q%d)_at_%d", id.c_str(), i, voq_ind, t);
             constr_expr = implies(pkt_dst != (int) ((leaf_id * servers_per_leaf) + i),
                                   out_queues[voq_ind]->enqs(0)[t] == net_ctx.null_pkt());
 
@@ -135,7 +135,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     not_valid_dsts.push_back(pkt_dst != (int) dst);
                 }
             }
-            sprintf(constr_name, "%s_no_match_port%d(q%d)_at_%d", id.c_str(), port_id, voq_ind, t);
+            snprintf(constr_name,100, "%s_no_match_port%d(q%d)_at_%d", id.c_str(), port_id, voq_ind, t);
             constr_expr = implies(mk_and(not_valid_dsts),
                                   out_queues[voq_ind]->enqs(0)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -154,8 +154,8 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     unsigned int dst = (leaf_id * servers_per_leaf) + i;
                     meta_bounds.push_back(pkt_meta == (int) dst);
                 }
-                sprintf(
-                    constr_name, "%s_dst_meta_bounds_for_input_queue[%d][%d]", id.c_str(), p, t);
+                snprintf(
+                    constr_name,100, "%s_dst_meta_bounds_for_input_queue[%d][%d]", id.c_str(), p, t);
                 constr_expr = implies(pkt_val, mk_or(meta_bounds));
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -170,7 +170,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     unsigned int dst = (leaf_id * servers_per_leaf) + i;
                     meta_bounds.push_back(pkt_meta == (int) dst);
                 }
-                sprintf(constr_name,
+                snprintf(constr_name,100,
                         "%s_dst_meta_bounds_for_input_queue_enq[%d][%d]",
                         id.c_str(),
                         p,
@@ -185,8 +185,8 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
                 unsigned int spine_id = fw_id - servers_per_leaf;
-                sprintf(
-                    constr_name, "%s_flow_meta_bounds_for_input_queue[%d][%d]", id.c_str(), p, t);
+                snprintf(
+                    constr_name,100, "%s_flow_meta_bounds_for_input_queue[%d][%d]", id.c_str(), p, t);
                 constr_expr = implies(pkt_val, pkt_meta == (int) spine_id);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -197,7 +197,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
                 unsigned int spine_id = fw_id - servers_per_leaf;
-                sprintf(constr_name,
+                snprintf(constr_name,100,
                         "%s_flow_meta_bounds_for_input_queue_enq[%d][%d]",
                         id.c_str(),
                         p,
@@ -213,7 +213,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta1(pkt);
 
-                sprintf(constr_name,
+                snprintf(constr_name,100,
                         "%s_dst_meta_bounds_for_input_queue_enq[%d][%d]",
                         id.c_str(),
                         p,
@@ -228,7 +228,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
-                sprintf(constr_name,
+                snprintf(constr_name,100,
                         "%s_flow_meta_bounds_for_input_queue_enq[%d][%d]",
                         id.c_str(),
                         p,
@@ -249,7 +249,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     expr pkt_val = net_ctx.pkt2val(pkt);
                     expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
-                    sprintf(constr_name, "%s_flow_meta_bounds_for_output_queue[%d][%d][%d]",
+                    snprintf(constr_name,100, "%s_flow_meta_bounds_for_output_queue[%d][%d][%d]",
             id.c_str(), voq_ind, p, t); constr_expr = implies(pkt_val, pkt_meta == (int) s);
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 }
@@ -259,7 +259,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
         // Don't enqueue into any port if packet is invalid
 
         for (unsigned int i = 0; i < out_queue_cnt(); i++) {
-            sprintf(constr_name, "%s_invalid_pkt_port_%d_at_%d", id.c_str(), i, t);
+            snprintf(constr_name,100, "%s_invalid_pkt_port_%d_at_%d", id.c_str(), i, t);
             constr_expr = implies(!pkt_val, out_queues[i]->enqs(0)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -267,7 +267,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
         // Make sure nothing else gets pushed to the output queue
         for (unsigned int i = 0; i < out_queue_cnt(); i++) {
             for (unsigned int e = 1; e < out_queues[i]->max_enq(); e++) {
-                sprintf(constr_name, "%s_out_%d_enqs[%d][%d]_is_null", id.c_str(), i, e, t);
+                snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_is_null", id.c_str(), i, e, t);
                 expr constr_expr = out_queues[i]->enqs(e)[t] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -281,7 +281,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt = queue->enqs(e)[t];
                 expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                sprintf(constr_name, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
+                snprintf(constr_name,100, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
                 expr constr_expr = meta3 <= (int) t && meta3 >= 0;
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -293,7 +293,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt = queue->enqs(e)[t];
                 expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                sprintf(constr_name, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
+                snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
                 unsigned int meta3_bound = t;
                 expr constr_expr = meta3 <= (int) meta3_bound && meta3 >= 0;
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -309,7 +309,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     expr pkt = queue->enqs(e)[t];
                     expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                    sprintf(constr_name, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
+                    snprintf(constr_name,100, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
                     unsigned int meta3_bound = 0;
                     if (t >= 2) meta3_bound = t - 2;
                     expr constr_expr = meta3 <= (int) meta3_bound && meta3 >= 0;
@@ -323,7 +323,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     expr pkt = queue->enqs(e)[t];
                     expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                    sprintf(constr_name, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
+                    snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
                     unsigned int meta3_bound = 0;
                     if (t >= 3) meta3_bound = t - 3;
                     expr constr_expr = meta3 <= (int) meta3_bound && meta3 >= 0;
@@ -338,7 +338,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     expr pkt = queue->enqs(e)[t];
                     expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                    sprintf(constr_name, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
+                    snprintf(constr_name,100, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
                     expr constr_expr = meta3 <= (int) t && meta3 >= 0;
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 }
@@ -350,7 +350,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     expr pkt = queue->enqs(e)[t];
                     expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                    sprintf(constr_name, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
+                    snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
                     unsigned int meta3_bound = 0;
                     if (t >= 1) meta3_bound = t - 1;
                     expr constr_expr = meta3 <= (int) meta3_bound && meta3 >= 0;

--- a/src/qms/leaf_forwarding_qm.cpp
+++ b/src/qms/leaf_forwarding_qm.cpp
@@ -47,7 +47,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
         expr dst_spine = net_ctx.pkt2meta2(in_pkt);
 
         // Set deq_cnt for input queue
-        snprintf(constr_name,100, "%s_in_queue_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_in_queue_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
         expr constr_expr = implies(pkt_val, in_queue->deq_cnt(t) == 1) &&
                            implies(!pkt_val, in_queue->deq_cnt(t) == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
@@ -79,12 +79,12 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 if (output_voq_map.find(dst_port) == output_voq_map.end()) continue;
                 unsigned int voq_ind = output_voq_map[dst_port];
 
-                snprintf(constr_name,100, "%s_forward_spine_%d_at_%d", id.c_str(), s, t);
+                snprintf(constr_name, 100, "%s_forward_spine_%d_at_%d", id.c_str(), s, t);
                 constr_expr = implies(pkt_val && dst_outside && dst_spine == (int) s,
                                       out_queues[voq_ind]->enqs(0)[t] == in_pkt);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
-                snprintf(constr_name,100, "%s_dont_forward_spine_%d_at_%d", id.c_str(), s, t);
+                snprintf(constr_name, 100, "%s_dont_forward_spine_%d_at_%d", id.c_str(), s, t);
 
                 constr_expr = implies(!dst_outside || dst_spine != (int) s,
                                       out_queues[voq_ind]->enqs(0)[t] == net_ctx.null_pkt());
@@ -99,12 +99,12 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
             if (output_voq_map.find(dst_port) == output_voq_map.end()) continue;
 
             unsigned int voq_ind = output_voq_map[dst_port];
-            snprintf(constr_name,100, "%s_forward_dst_%d_at_%d", id.c_str(), dst, t);
+            snprintf(constr_name, 100, "%s_forward_dst_%d_at_%d", id.c_str(), dst, t);
             constr_expr = implies(pkt_val && pkt_dst == (int) dst,
                                   out_queues[voq_ind]->enqs(0)[t] == in_pkt);
             constr_map.insert(named_constr(constr_name, constr_expr));
 
-            snprintf(constr_name,100, "%s_dont_forward_dst_%d_at_%d", id.c_str(), dst, t);
+            snprintf(constr_name, 100, "%s_dont_forward_dst_%d_at_%d", id.c_str(), dst, t);
             constr_expr = implies(pkt_dst != (int) dst,
                                   out_queues[voq_ind]->enqs(0)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -135,10 +135,9 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     not_valid_dsts.push_back(pkt_dst != (int) dst);
                 }
             }
-            snprintf(constr_name,100, "%s_no_match_port%d(q%d)_at_%d", id.c_str(), port_id, voq_ind, t);
-            constr_expr = implies(mk_and(not_valid_dsts),
-                                  out_queues[voq_ind]->enqs(0)[t] == net_ctx.null_pkt());
-            constr_map.insert(named_constr(constr_name, constr_expr));
+            snprintf(constr_name,100, "%s_no_match_port%d(q%d)_at_%d", id.c_str(), port_id, voq_ind,
+        t); constr_expr = implies(mk_and(not_valid_dsts), out_queues[voq_ind]->enqs(0)[t] ==
+        net_ctx.null_pkt()); constr_map.insert(named_constr(constr_name, constr_expr));
         }*/
 
         // Bounds on packet meta
@@ -154,8 +153,12 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     unsigned int dst = (leaf_id * servers_per_leaf) + i;
                     meta_bounds.push_back(pkt_meta == (int) dst);
                 }
-                snprintf(
-                    constr_name,100, "%s_dst_meta_bounds_for_input_queue[%d][%d]", id.c_str(), p, t);
+                snprintf(constr_name,
+                         100,
+                         "%s_dst_meta_bounds_for_input_queue[%d][%d]",
+                         id.c_str(),
+                         p,
+                         t);
                 constr_expr = implies(pkt_val, mk_or(meta_bounds));
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -170,11 +173,12 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     unsigned int dst = (leaf_id * servers_per_leaf) + i;
                     meta_bounds.push_back(pkt_meta == (int) dst);
                 }
-                snprintf(constr_name,100,
-                        "%s_dst_meta_bounds_for_input_queue_enq[%d][%d]",
-                        id.c_str(),
-                        p,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_dst_meta_bounds_for_input_queue_enq[%d][%d]",
+                         id.c_str(),
+                         p,
+                         t);
                 constr_expr = implies(pkt_val, mk_or(meta_bounds));
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -185,8 +189,12 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
                 unsigned int spine_id = fw_id - servers_per_leaf;
-                snprintf(
-                    constr_name,100, "%s_flow_meta_bounds_for_input_queue[%d][%d]", id.c_str(), p, t);
+                snprintf(constr_name,
+                         100,
+                         "%s_flow_meta_bounds_for_input_queue[%d][%d]",
+                         id.c_str(),
+                         p,
+                         t);
                 constr_expr = implies(pkt_val, pkt_meta == (int) spine_id);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -197,11 +205,12 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
                 unsigned int spine_id = fw_id - servers_per_leaf;
-                snprintf(constr_name,100,
-                        "%s_flow_meta_bounds_for_input_queue_enq[%d][%d]",
-                        id.c_str(),
-                        p,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_flow_meta_bounds_for_input_queue_enq[%d][%d]",
+                         id.c_str(),
+                         p,
+                         t);
                 constr_expr = implies(pkt_val, pkt_meta == (int) spine_id);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -213,11 +222,12 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta1(pkt);
 
-                snprintf(constr_name,100,
-                        "%s_dst_meta_bounds_for_input_queue_enq[%d][%d]",
-                        id.c_str(),
-                        p,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_dst_meta_bounds_for_input_queue_enq[%d][%d]",
+                         id.c_str(),
+                         p,
+                         t);
                 unsigned int qid = (leaf_id * servers_per_leaf) + fw_id;
                 constr_expr = pkt_meta >= 0 && pkt_meta < (int) server_cnt && pkt_meta != (int) qid;
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -228,11 +238,12 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
-                snprintf(constr_name,100,
-                        "%s_flow_meta_bounds_for_input_queue_enq[%d][%d]",
-                        id.c_str(),
-                        p,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_flow_meta_bounds_for_input_queue_enq[%d][%d]",
+                         id.c_str(),
+                         p,
+                         t);
                 constr_expr = implies(pkt_val, pkt_meta >= 0 && pkt_meta < (int) spine_cnt);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -259,7 +270,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
         // Don't enqueue into any port if packet is invalid
 
         for (unsigned int i = 0; i < out_queue_cnt(); i++) {
-            snprintf(constr_name,100, "%s_invalid_pkt_port_%d_at_%d", id.c_str(), i, t);
+            snprintf(constr_name, 100, "%s_invalid_pkt_port_%d_at_%d", id.c_str(), i, t);
             constr_expr = implies(!pkt_val, out_queues[i]->enqs(0)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -267,7 +278,7 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
         // Make sure nothing else gets pushed to the output queue
         for (unsigned int i = 0; i < out_queue_cnt(); i++) {
             for (unsigned int e = 1; e < out_queues[i]->max_enq(); e++) {
-                snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_is_null", id.c_str(), i, e, t);
+                snprintf(constr_name, 100, "%s_out_%d_enqs[%d][%d]_is_null", id.c_str(), i, e, t);
                 expr constr_expr = out_queues[i]->enqs(e)[t] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -293,10 +304,9 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr pkt = queue->enqs(e)[t];
                 expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
-                unsigned int meta3_bound = t;
-                expr constr_expr = meta3 <= (int) meta3_bound && meta3 >= 0;
-                constr_map.insert(named_constr(constr_name, constr_expr));
+                snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e,
+        t); unsigned int meta3_bound = t; expr constr_expr = meta3 <= (int) meta3_bound && meta3 >=
+        0; constr_map.insert(named_constr(constr_name, constr_expr));
             }
         }
         */
@@ -309,11 +319,10 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     expr pkt = queue->enqs(e)[t];
                     expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                    snprintf(constr_name,100, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
-                    unsigned int meta3_bound = 0;
-                    if (t >= 2) meta3_bound = t - 2;
-                    expr constr_expr = meta3 <= (int) meta3_bound && meta3 >= 0;
-                    constr_map.insert(named_constr(constr_name, constr_expr));
+                    snprintf(constr_name,100, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e,
+        t); unsigned int meta3_bound = 0; if (t >= 2) meta3_bound = t - 2; expr constr_expr = meta3
+        <= (int) meta3_bound && meta3 >= 0; constr_map.insert(named_constr(constr_name,
+        constr_expr));
                 }
             }
 
@@ -323,11 +332,10 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     expr pkt = queue->enqs(e)[t];
                     expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                    snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
-                    unsigned int meta3_bound = 0;
-                    if (t >= 3) meta3_bound = t - 3;
-                    expr constr_expr = meta3 <= (int) meta3_bound && meta3 >= 0;
-                    constr_map.insert(named_constr(constr_name, constr_expr));
+                    snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i,
+        e, t); unsigned int meta3_bound = 0; if (t >= 3) meta3_bound = t - 3; expr constr_expr =
+        meta3 <= (int) meta3_bound && meta3 >= 0; constr_map.insert(named_constr(constr_name,
+        constr_expr));
                 }
             }
         }
@@ -338,8 +346,8 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     expr pkt = queue->enqs(e)[t];
                     expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                    snprintf(constr_name,100, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
-                    expr constr_expr = meta3 <= (int) t && meta3 >= 0;
+                    snprintf(constr_name,100, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e,
+        t); expr constr_expr = meta3 <= (int) t && meta3 >= 0;
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 }
             }
@@ -350,11 +358,10 @@ void LeafForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& const
                     expr pkt = queue->enqs(e)[t];
                     expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                    snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
-                    unsigned int meta3_bound = 0;
-                    if (t >= 1) meta3_bound = t - 1;
-                    expr constr_expr = meta3 <= (int) meta3_bound && meta3 >= 0;
-                    constr_map.insert(named_constr(constr_name, constr_expr));
+                    snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i,
+        e, t); unsigned int meta3_bound = 0; if (t >= 1) meta3_bound = t - 1; expr constr_expr =
+        meta3 <= (int) meta3_bound && meta3 >= 0; constr_map.insert(named_constr(constr_name,
+        constr_expr));
                 }
             }
         }*/

--- a/src/qms/loom_demux_qm.cpp
+++ b/src/qms/loom_demux_qm.cpp
@@ -41,41 +41,41 @@ void LoomDemuxQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
         expr not_empty = net_ctx.pkt2val(head_pkt);
 
         // If not empty, deq one from the input queue
-        snprintf(constr_name,100, "%s_input_deq_cnt_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_input_deq_cnt_%d", id.c_str(), t);
         expr constr_expr = implies(not_empty, input_queue->deq_cnt(t) == 1);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // Decide which output queue to put the packet in
         expr pkt_class = net_ctx.pkt2meta1(head_pkt);
-        snprintf(constr_name,100, "%s_tenant1_pkt_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_tenant1_pkt_%d", id.c_str(), t);
         constr_expr = implies(not_empty && pkt_class == (int) tenant1_spark,
                               out_queues[0]->enqs(0)[t] == head_pkt);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        snprintf(constr_name,100, "%s_not_tenant1_pkt_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_not_tenant1_pkt_%d", id.c_str(), t);
         constr_expr = implies(not_empty && pkt_class != (int) tenant1_spark,
                               out_queues[0]->enqs(0)[t] == net_ctx.null_pkt());
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        snprintf(constr_name,100, "%s_tenant2_pkt_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_tenant2_pkt_%d", id.c_str(), t);
         constr_expr = implies(not_empty && (pkt_class == (int) tenant2_spark ||
                                             pkt_class == (int) tenant2_memcached),
                               out_queues[1]->enqs(0)[t] == head_pkt);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        snprintf(constr_name,100, "%s_not_tenant2_pkt_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_not_tenant2_pkt_%d", id.c_str(), t);
         constr_expr = implies(not_empty && (pkt_class != (int) tenant2_spark &&
                                             pkt_class != (int) tenant2_memcached),
                               out_queues[1]->enqs(0)[t] == net_ctx.null_pkt());
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // Take care of the case where the input queue is empty
-        snprintf(constr_name,100, "%s_empty_input_no_deq_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_empty_input_no_deq_%d", id.c_str(), t);
         constr_expr = implies(!not_empty, input_queue->deq_cnt(t) == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         for (unsigned int q = 0; q < out_queues.size(); q++) {
-            snprintf(constr_name,100, "%s_empty_input_no_enq_%d_%d", id.c_str(), q, t);
+            snprintf(constr_name, 100, "%s_empty_input_no_enq_%d_%d", id.c_str(), q, t);
             expr constr_expr = implies(!not_empty, out_queues[q]->enqs(0)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -85,7 +85,7 @@ void LoomDemuxQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
         for (unsigned int q = 0; q < out_queues.size(); q++) {
             Queue* outq = out_queues[q];
             for (unsigned int i = 1; i < outq->max_enq(); i++) {
-                snprintf(constr_name,100, "%s_only_one_output_%d_%d_%d", id.c_str(), q, i, t);
+                snprintf(constr_name, 100, "%s_only_one_output_%d_%d_%d", id.c_str(), q, i, t);
                 expr constr_expr = outq->enqs(i)[t] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }

--- a/src/qms/loom_demux_qm.cpp
+++ b/src/qms/loom_demux_qm.cpp
@@ -41,41 +41,41 @@ void LoomDemuxQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
         expr not_empty = net_ctx.pkt2val(head_pkt);
 
         // If not empty, deq one from the input queue
-        sprintf(constr_name, "%s_input_deq_cnt_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_input_deq_cnt_%d", id.c_str(), t);
         expr constr_expr = implies(not_empty, input_queue->deq_cnt(t) == 1);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // Decide which output queue to put the packet in
         expr pkt_class = net_ctx.pkt2meta1(head_pkt);
-        sprintf(constr_name, "%s_tenant1_pkt_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_tenant1_pkt_%d", id.c_str(), t);
         constr_expr = implies(not_empty && pkt_class == (int) tenant1_spark,
                               out_queues[0]->enqs(0)[t] == head_pkt);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        sprintf(constr_name, "%s_not_tenant1_pkt_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_not_tenant1_pkt_%d", id.c_str(), t);
         constr_expr = implies(not_empty && pkt_class != (int) tenant1_spark,
                               out_queues[0]->enqs(0)[t] == net_ctx.null_pkt());
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        sprintf(constr_name, "%s_tenant2_pkt_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_tenant2_pkt_%d", id.c_str(), t);
         constr_expr = implies(not_empty && (pkt_class == (int) tenant2_spark ||
                                             pkt_class == (int) tenant2_memcached),
                               out_queues[1]->enqs(0)[t] == head_pkt);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        sprintf(constr_name, "%s_not_tenant2_pkt_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_not_tenant2_pkt_%d", id.c_str(), t);
         constr_expr = implies(not_empty && (pkt_class != (int) tenant2_spark &&
                                             pkt_class != (int) tenant2_memcached),
                               out_queues[1]->enqs(0)[t] == net_ctx.null_pkt());
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // Take care of the case where the input queue is empty
-        sprintf(constr_name, "%s_empty_input_no_deq_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_empty_input_no_deq_%d", id.c_str(), t);
         constr_expr = implies(!not_empty, input_queue->deq_cnt(t) == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         for (unsigned int q = 0; q < out_queues.size(); q++) {
-            sprintf(constr_name, "%s_empty_input_no_enq_%d_%d", id.c_str(), q, t);
+            snprintf(constr_name,100, "%s_empty_input_no_enq_%d_%d", id.c_str(), q, t);
             expr constr_expr = implies(!not_empty, out_queues[q]->enqs(0)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -85,7 +85,7 @@ void LoomDemuxQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map
         for (unsigned int q = 0; q < out_queues.size(); q++) {
             Queue* outq = out_queues[q];
             for (unsigned int i = 1; i < outq->max_enq(); i++) {
-                sprintf(constr_name, "%s_only_one_output_%d_%d_%d", id.c_str(), q, i, t);
+                snprintf(constr_name,100, "%s_only_one_output_%d_%d_%d", id.c_str(), q, i, t);
                 expr constr_expr = outq->enqs(i)[t] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }

--- a/src/qms/loom_flow_enq_qm.cpp
+++ b/src/qms/loom_flow_enq_qm.cpp
@@ -45,12 +45,12 @@ void LoomFlowEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>&
         for (unsigned int i = 0; i < tenant1_outq->max_enq(); i++) {
             expr in_pkt = tenant1_inq->elem(i)[t];
             // set enqs of the output queue equal to the first max_enq packets of input queue
-            sprintf(constr_name, "%s_tenant1_out_enqs[%d][%d]", id.c_str(), i, t);
+            snprintf(constr_name,100, "%s_tenant1_out_enqs[%d][%d]", id.c_str(), i, t);
             expr constr_expr = tenant1_outq->enqs(i)[t] == in_pkt;
             constr_map.insert(named_constr(constr_name, constr_expr));
 
             // set deq_cnt of input queue based on validity of enqs of output queue most max_enq
-            sprintf(constr_name, "%s_tenant1_in_deq_cnt[%d]_is_%d", id.c_str(), t, i);
+            snprintf(constr_name,100, "%s_tenant1_in_deq_cnt[%d]_is_%d", id.c_str(), t, i);
             constr_expr = implies(net_ctx.pkt2val(in_pkt), tenant1_inq->deq_cnt(t) > (int) i);
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -76,7 +76,7 @@ void LoomFlowEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>&
                 expr in_pkt = in_queues[qid]->elem(offset)[t];
                 expr cond = (prev_elems_invalid && net_ctx.pkt2val(in_pkt));
 
-                sprintf(constr_name,
+                snprintf(constr_name,100,
                         "%s_tenant2_out_enqs[%d][%d]_is_inq[%d][%d]",
                         id.c_str(),
                         i,
@@ -90,7 +90,7 @@ void LoomFlowEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>&
                 string app_name = "spark";
                 if (qid == 2) app_name = "memcached";
 
-                sprintf(constr_name,
+                snprintf(constr_name,100,
                         "%s_tenant2_%s_deq_cnt[%d]_is_gt_%d_because_%d",
                         id.c_str(),
                         app_name.c_str(),
@@ -106,7 +106,7 @@ void LoomFlowEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>&
                 le_i_gets_j[j] = le_i_gets_j[j] || cond;
             }
 
-            sprintf(constr_name, "%s_tenant2_out_enqs[%d][%d]_is_null", id.c_str(), i, t);
+            snprintf(constr_name,100, "%s_tenant2_out_enqs[%d][%d]_is_null", id.c_str(), i, t);
             expr constr_expr = implies(prev_elems_invalid,
                                        tenant2_outq->enqs(i)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -122,7 +122,7 @@ void LoomFlowEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>&
             if (q == 2) queue_class = tenant2_memcached;
 
             for (unsigned int i = 0; i < in_queues[q]->max_enq(); i++) {
-                sprintf(constr_name, "%s_only_valid_meta_in_enq[%d][%d][%d]", id.c_str(), q, i, t);
+                snprintf(constr_name,100, "%s_only_valid_meta_in_enq[%d][%d][%d]", id.c_str(), q, i, t);
                 expr pkt = in_queues[q]->enqs(i)[t];
                 expr pkt_class = net_ctx.pkt2meta1(pkt);
                 expr constr_expr = implies(net_ctx.pkt2val(pkt), pkt_class == queue_class);

--- a/src/qms/loom_flow_enq_qm.cpp
+++ b/src/qms/loom_flow_enq_qm.cpp
@@ -45,12 +45,12 @@ void LoomFlowEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>&
         for (unsigned int i = 0; i < tenant1_outq->max_enq(); i++) {
             expr in_pkt = tenant1_inq->elem(i)[t];
             // set enqs of the output queue equal to the first max_enq packets of input queue
-            snprintf(constr_name,100, "%s_tenant1_out_enqs[%d][%d]", id.c_str(), i, t);
+            snprintf(constr_name, 100, "%s_tenant1_out_enqs[%d][%d]", id.c_str(), i, t);
             expr constr_expr = tenant1_outq->enqs(i)[t] == in_pkt;
             constr_map.insert(named_constr(constr_name, constr_expr));
 
             // set deq_cnt of input queue based on validity of enqs of output queue most max_enq
-            snprintf(constr_name,100, "%s_tenant1_in_deq_cnt[%d]_is_%d", id.c_str(), t, i);
+            snprintf(constr_name, 100, "%s_tenant1_in_deq_cnt[%d]_is_%d", id.c_str(), t, i);
             constr_expr = implies(net_ctx.pkt2val(in_pkt), tenant1_inq->deq_cnt(t) > (int) i);
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -76,13 +76,14 @@ void LoomFlowEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>&
                 expr in_pkt = in_queues[qid]->elem(offset)[t];
                 expr cond = (prev_elems_invalid && net_ctx.pkt2val(in_pkt));
 
-                snprintf(constr_name,100,
-                        "%s_tenant2_out_enqs[%d][%d]_is_inq[%d][%d]",
-                        id.c_str(),
-                        i,
-                        t,
-                        qid,
-                        offset);
+                snprintf(constr_name,
+                         100,
+                         "%s_tenant2_out_enqs[%d][%d]_is_inq[%d][%d]",
+                         id.c_str(),
+                         i,
+                         t,
+                         qid,
+                         offset);
                 expr constr_expr = implies(cond && !le_i_gets_j[j],
                                            tenant2_outq->enqs(i)[t] == in_pkt);
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -90,13 +91,14 @@ void LoomFlowEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>&
                 string app_name = "spark";
                 if (qid == 2) app_name = "memcached";
 
-                snprintf(constr_name,100,
-                        "%s_tenant2_%s_deq_cnt[%d]_is_gt_%d_because_%d",
-                        id.c_str(),
-                        app_name.c_str(),
-                        t,
-                        offset,
-                        i);
+                snprintf(constr_name,
+                         100,
+                         "%s_tenant2_%s_deq_cnt[%d]_is_gt_%d_because_%d",
+                         id.c_str(),
+                         app_name.c_str(),
+                         t,
+                         offset,
+                         i);
                 constr_expr = implies(cond && !le_i_gets_j[j],
                                       in_queues[qid]->deq_cnt(t) > (int) offset);
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -106,7 +108,7 @@ void LoomFlowEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>&
                 le_i_gets_j[j] = le_i_gets_j[j] || cond;
             }
 
-            snprintf(constr_name,100, "%s_tenant2_out_enqs[%d][%d]_is_null", id.c_str(), i, t);
+            snprintf(constr_name, 100, "%s_tenant2_out_enqs[%d][%d]_is_null", id.c_str(), i, t);
             expr constr_expr = implies(prev_elems_invalid,
                                        tenant2_outq->enqs(i)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -122,7 +124,8 @@ void LoomFlowEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>&
             if (q == 2) queue_class = tenant2_memcached;
 
             for (unsigned int i = 0; i < in_queues[q]->max_enq(); i++) {
-                snprintf(constr_name,100, "%s_only_valid_meta_in_enq[%d][%d][%d]", id.c_str(), q, i, t);
+                snprintf(
+                    constr_name, 100, "%s_only_valid_meta_in_enq[%d][%d][%d]", id.c_str(), q, i, t);
                 expr pkt = in_queues[q]->enqs(i)[t];
                 expr pkt_class = net_ctx.pkt2meta1(pkt);
                 expr constr_expr = implies(net_ctx.pkt2val(pkt), pkt_class == queue_class);

--- a/src/qms/loom_nic_enq_qm.cpp
+++ b/src/qms/loom_nic_enq_qm.cpp
@@ -53,7 +53,7 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
                 expr pkt_val = net_ctx.pkt2val(in_pkt);
 
                 // Set deq_cnt bounds
-                sprintf(constr_name, "%s_input_deq_cnt_lb[%d][%d]_%d", id.c_str(), q, t, i);
+                snprintf(constr_name,100, "%s_input_deq_cnt_lb[%d][%d]_%d", id.c_str(), q, t, i);
                 expr constr_expr = implies(pkt_val, inq->deq_cnt(t) > (int) i);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -76,7 +76,7 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
                 expr pkt_val = net_ctx.pkt2val(src_pkt);
                 expr pkt_class = net_ctx.pkt2meta1(src_pkt);
 
-                sprintf(constr_name,
+                snprintf(constr_name,100,
                         "%s_memcached_enq[%d]_in[%d][%d]_%d",
                         id.c_str(),
                         i,
@@ -94,7 +94,7 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
                 le_i_gets_j[j] = le_i_gets_j[j] || cond;
             }
 
-            sprintf(constr_name, "%s_memcached_enq[%d]_null_%d", id.c_str(), i, t);
+            snprintf(constr_name,100, "%s_memcached_enq[%d]_null_%d", id.c_str(), i, t);
             expr constr_expr = implies(prev_elems_invalid, dst_pkt == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -115,7 +115,7 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
                 expr pkt_val = net_ctx.pkt2val(src_pkt);
                 expr pkt_class = net_ctx.pkt2meta1(src_pkt);
 
-                sprintf(constr_name,
+                snprintf(constr_name,100,
                         "%s_spark_enq[%d]_in[%d][%d]_%d",
                         id.c_str(),
                         i,
@@ -136,7 +136,7 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
                 le_i_gets_j[j] = le_i_gets_j[j] || cond;
             }
 
-            sprintf(constr_name, "%s_spark_enq[%d]_null_%d", id.c_str(), i, t);
+            snprintf(constr_name,100, "%s_spark_enq[%d]_null_%d", id.c_str(), i, t);
             expr constr_expr = implies(prev_elems_invalid, dst_pkt == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -145,7 +145,7 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
         for (unsigned int q = 0; q < out_queues.size(); q++) {
             Queue* outq = out_queues[q];
             for (unsigned int i = per_queue_share * in_queue_cnt; i < outq->max_enq(); i++) {
-                sprintf(constr_name, "%s_null_rest_of_output_%d_%d_%d", id.c_str(), q, i, t);
+                snprintf(constr_name,100, "%s_null_rest_of_output_%d_%d_%d", id.c_str(), q, i, t);
                 expr constr_expr = outq->enqs(i)[t] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }

--- a/src/qms/loom_nic_enq_qm.cpp
+++ b/src/qms/loom_nic_enq_qm.cpp
@@ -53,7 +53,7 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
                 expr pkt_val = net_ctx.pkt2val(in_pkt);
 
                 // Set deq_cnt bounds
-                snprintf(constr_name,100, "%s_input_deq_cnt_lb[%d][%d]_%d", id.c_str(), q, t, i);
+                snprintf(constr_name, 100, "%s_input_deq_cnt_lb[%d][%d]_%d", id.c_str(), q, t, i);
                 expr constr_expr = implies(pkt_val, inq->deq_cnt(t) > (int) i);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -76,13 +76,14 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
                 expr pkt_val = net_ctx.pkt2val(src_pkt);
                 expr pkt_class = net_ctx.pkt2meta1(src_pkt);
 
-                snprintf(constr_name,100,
-                        "%s_memcached_enq[%d]_in[%d][%d]_%d",
-                        id.c_str(),
-                        i,
-                        src_qid,
-                        src_elem_id,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_memcached_enq[%d]_in[%d][%d]_%d",
+                         id.c_str(),
+                         i,
+                         src_qid,
+                         src_elem_id,
+                         t);
                 expr cond = (prev_elems_invalid && pkt_val && pkt_class == (int) tenant2_memcached);
                 expr constr_expr = implies(cond && !le_i_gets_j[j], dst_pkt == src_pkt);
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -94,7 +95,7 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
                 le_i_gets_j[j] = le_i_gets_j[j] || cond;
             }
 
-            snprintf(constr_name,100, "%s_memcached_enq[%d]_null_%d", id.c_str(), i, t);
+            snprintf(constr_name, 100, "%s_memcached_enq[%d]_null_%d", id.c_str(), i, t);
             expr constr_expr = implies(prev_elems_invalid, dst_pkt == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -115,13 +116,14 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
                 expr pkt_val = net_ctx.pkt2val(src_pkt);
                 expr pkt_class = net_ctx.pkt2meta1(src_pkt);
 
-                snprintf(constr_name,100,
-                        "%s_spark_enq[%d]_in[%d][%d]_%d",
-                        id.c_str(),
-                        i,
-                        src_qid,
-                        src_elem_id,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_spark_enq[%d]_in[%d][%d]_%d",
+                         id.c_str(),
+                         i,
+                         src_qid,
+                         src_elem_id,
+                         t);
                 expr cond = (prev_elems_invalid && pkt_val &&
                              (pkt_class == (int) tenant1_spark ||
                               pkt_class == (int) tenant2_spark));
@@ -136,7 +138,7 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
                 le_i_gets_j[j] = le_i_gets_j[j] || cond;
             }
 
-            snprintf(constr_name,100, "%s_spark_enq[%d]_null_%d", id.c_str(), i, t);
+            snprintf(constr_name, 100, "%s_spark_enq[%d]_null_%d", id.c_str(), i, t);
             expr constr_expr = implies(prev_elems_invalid, dst_pkt == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -145,7 +147,7 @@ void LoomNICEnqQM::constrs_if_not_taken(NetContext& net_ctx, map<string, expr>& 
         for (unsigned int q = 0; q < out_queues.size(); q++) {
             Queue* outq = out_queues[q];
             for (unsigned int i = per_queue_share * in_queue_cnt; i < outq->max_enq(); i++) {
-                snprintf(constr_name,100, "%s_null_rest_of_output_%d_%d_%d", id.c_str(), q, i, t);
+                snprintf(constr_name, 100, "%s_null_rest_of_output_%d_%d_%d", id.c_str(), q, i, t);
                 expr constr_expr = outq->enqs(i)[t] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }

--- a/src/qms/priority_qm.cpp
+++ b/src/qms/priority_qm.cpp
@@ -28,7 +28,7 @@ void PriorityQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
     for (unsigned int t = 0; t < total_time; t++) {
         // Find the highest priority queue to pull from
         expr not_empty = net_ctx.pkt2val(in_queues[0]->elem(0)[t]);
-        sprintf(constr_name, "%s_deq_cnt_0_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_deq_cnt_0_%d", id.c_str(), t);
         expr constr_expr = in_queues[0]->deq_cnt(t) ==
                            ite(not_empty, net_ctx.int_val(1), net_ctx.int_val(0));
 
@@ -37,7 +37,7 @@ void PriorityQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
         expr higher_empty = !not_empty;
         for (unsigned int q = 1; q < in_queues.size(); q++) {
             not_empty = net_ctx.pkt2val(in_queues[q]->elem(0)[t]);
-            sprintf(constr_name, "%s_deq_cnt_%d_%d", id.c_str(), q, t);
+            snprintf(constr_name,100, "%s_deq_cnt_%d_%d", id.c_str(), q, t);
             expr constr_expr = in_queues[q]->deq_cnt(t) == ite(higher_empty && not_empty,
                                                                net_ctx.int_val(1),
                                                                net_ctx.int_val(0));
@@ -49,7 +49,7 @@ void PriorityQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
         // Push to output queue accordingly
         Queue* outq = out_queues[0];
         for (unsigned int q = 0; q < in_queues.size(); q++) {
-            sprintf(constr_name, "%s_output_from_%d_%d", id.c_str(), q, t);
+            snprintf(constr_name,100, "%s_output_from_%d_%d", id.c_str(), q, t);
             expr constr_expr = implies(in_queues[q]->deq_cnt(t) == 1,
                                        outq->enqs(0)[t] == in_queues[q]->elem(0)[t]);
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -60,13 +60,13 @@ void PriorityQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
         for (unsigned int q = 0; q < in_queues.size(); q++) {
             all_empty.push_back(!net_ctx.pkt2val(in_queues[q]->elem(0)[t]));
         }
-        sprintf(constr_name, "%s_all_empty_input_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_all_empty_input_%d", id.c_str(), t);
         constr_expr = implies(mk_and(all_empty), outq->enqs(0)[t] == net_ctx.null_pkt());
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // Make sure nothing else gets pushed to the output queue
         for (unsigned int i = 1; i < outq->max_enq(); i++) {
-            sprintf(constr_name, "%s_only_one_output_%d_%d", id.c_str(), i, t);
+            snprintf(constr_name,100, "%s_only_one_output_%d_%d", id.c_str(), i, t);
             expr constr_expr = outq->enqs(i)[t] == net_ctx.null_pkt();
             constr_map.insert(named_constr(constr_name, constr_expr));
         }

--- a/src/qms/priority_qm.cpp
+++ b/src/qms/priority_qm.cpp
@@ -28,7 +28,7 @@ void PriorityQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
     for (unsigned int t = 0; t < total_time; t++) {
         // Find the highest priority queue to pull from
         expr not_empty = net_ctx.pkt2val(in_queues[0]->elem(0)[t]);
-        snprintf(constr_name,100, "%s_deq_cnt_0_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_deq_cnt_0_%d", id.c_str(), t);
         expr constr_expr = in_queues[0]->deq_cnt(t) ==
                            ite(not_empty, net_ctx.int_val(1), net_ctx.int_val(0));
 
@@ -37,7 +37,7 @@ void PriorityQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
         expr higher_empty = !not_empty;
         for (unsigned int q = 1; q < in_queues.size(); q++) {
             not_empty = net_ctx.pkt2val(in_queues[q]->elem(0)[t]);
-            snprintf(constr_name,100, "%s_deq_cnt_%d_%d", id.c_str(), q, t);
+            snprintf(constr_name, 100, "%s_deq_cnt_%d_%d", id.c_str(), q, t);
             expr constr_expr = in_queues[q]->deq_cnt(t) == ite(higher_empty && not_empty,
                                                                net_ctx.int_val(1),
                                                                net_ctx.int_val(0));
@@ -49,7 +49,7 @@ void PriorityQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
         // Push to output queue accordingly
         Queue* outq = out_queues[0];
         for (unsigned int q = 0; q < in_queues.size(); q++) {
-            snprintf(constr_name,100, "%s_output_from_%d_%d", id.c_str(), q, t);
+            snprintf(constr_name, 100, "%s_output_from_%d_%d", id.c_str(), q, t);
             expr constr_expr = implies(in_queues[q]->deq_cnt(t) == 1,
                                        outq->enqs(0)[t] == in_queues[q]->elem(0)[t]);
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -60,13 +60,13 @@ void PriorityQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
         for (unsigned int q = 0; q < in_queues.size(); q++) {
             all_empty.push_back(!net_ctx.pkt2val(in_queues[q]->elem(0)[t]));
         }
-        snprintf(constr_name,100, "%s_all_empty_input_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_all_empty_input_%d", id.c_str(), t);
         constr_expr = implies(mk_and(all_empty), outq->enqs(0)[t] == net_ctx.null_pkt());
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // Make sure nothing else gets pushed to the output queue
         for (unsigned int i = 1; i < outq->max_enq(); i++) {
-            snprintf(constr_name,100, "%s_only_one_output_%d_%d", id.c_str(), i, t);
+            snprintf(constr_name, 100, "%s_only_one_output_%d_%d", id.c_str(), i, t);
             expr constr_expr = outq->enqs(i)[t] == net_ctx.null_pkt();
             constr_map.insert(named_constr(constr_name, constr_expr));
         }

--- a/src/qms/rr_qm.cpp
+++ b/src/qms/rr_qm.cpp
@@ -22,7 +22,7 @@ void RRQM::add_proc_vars(NetContext& net_ctx) {
     for (unsigned int q = 0; q < in_queues.size(); q++) {
         for (unsigned int t = 0; t < total_time; t++) {
             char vname[100];
-            snprintf(vname,100, "%s_last_served_queue[%d][%d]", id.c_str(), q, t);
+            snprintf(vname, 100, "%s_last_served_queue[%d][%d]", id.c_str(), q, t);
             last_served_queue_[q].push_back(net_ctx.bool_const(vname));
         }
     }
@@ -35,11 +35,11 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
 
 
     for (unsigned int q = 0; q < in_queues.size() - 1; q++) {
-        snprintf(constr_name,100, "%s_%d_not_lsq_at_0", id.c_str(), q);
+        snprintf(constr_name, 100, "%s_%d_not_lsq_at_0", id.c_str(), q);
         expr constr_expr = !last_served_queue_[q][0];
         constr_map.insert(named_constr(constr_name, constr_expr));
     }
-    snprintf(constr_name,100, "%s_%d_lsq_at_0", id.c_str(), (unsigned int) in_queues.size() - 1);
+    snprintf(constr_name, 100, "%s_%d_lsq_at_0", id.c_str(), (unsigned int) in_queues.size() - 1);
     expr constr_expr = last_served_queue_[in_queues.size() - 1][0];
     constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -52,7 +52,7 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
 
             unsigned int q = (h + 1) % in_queue_cnt;
             expr not_empty = net_ctx.pkt2val(in_queues[q]->elem(0)[t]);
-            snprintf(constr_name,100, "%s_head_%d_deq_cnt_%d_%d", id.c_str(), h, q, t);
+            snprintf(constr_name, 100, "%s_head_%d_deq_cnt_%d_%d", id.c_str(), h, q, t);
             constr_expr = implies(last_served_queue_[h][t],
                                   in_queues[q]->deq_cnt(t) ==
                                       ite(not_empty, net_ctx.int_val(1), net_ctx.int_val(0)));
@@ -65,7 +65,7 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
                 q = (h + i) % in_queue_cnt;
 
                 not_empty = net_ctx.pkt2val(in_queues[q]->elem(0)[t]);
-                snprintf(constr_name,100, "%s_head_%d_deq_cnt_%d_%d", id.c_str(), h, q, t);
+                snprintf(constr_name, 100, "%s_head_%d_deq_cnt_%d_%d", id.c_str(), h, q, t);
                 constr_expr = implies(last_served_queue_[h][t],
                                       in_queues[q]->deq_cnt(t) == ite(prev_empty && not_empty,
                                                                       net_ctx.int_val(1),
@@ -79,7 +79,7 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
         // Push to output queue accordingly
         Queue* outq = out_queues[0];
         for (unsigned int q = 0; q < in_queue_cnt; q++) {
-            snprintf(constr_name,100, "%s_output_from_%d_%d", id.c_str(), q, t);
+            snprintf(constr_name, 100, "%s_output_from_%d_%d", id.c_str(), q, t);
             constr_expr = implies(in_queues[q]->deq_cnt(t) == 1,
                                   outq->enqs(0)[t] == in_queues[q]->elem(0)[t]);
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -92,23 +92,23 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
             all_empty.push_back(!net_ctx.pkt2val(in_queues[q]->elem(0)[t]));
             non_empty.push_back(net_ctx.pkt2val(in_queues[q]->elem(0)[t]));
         }
-        snprintf(constr_name,100, "%s_all_empty_input_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_all_empty_input_%d", id.c_str(), t);
         constr_expr = implies(mk_and(all_empty), outq->enqs(0)[t] == net_ctx.null_pkt());
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // Update head
         if (t != total_time - 1) {
             for (unsigned int q = 0; q < in_queue_cnt; q++) {
-                snprintf(constr_name,100, "%s_lsq_%d_at_%d_is_one", id.c_str(), q, t);
+                snprintf(constr_name, 100, "%s_lsq_%d_at_%d_is_one", id.c_str(), q, t);
                 constr_expr = implies(in_queues[q]->deq_cnt(t) > 0, last_served_queue_[q][t + 1]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
-                snprintf(constr_name,100, "%s_lsq_%d_at_%d_is_zero", id.c_str(), q, t);
+                snprintf(constr_name, 100, "%s_lsq_%d_at_%d_is_zero", id.c_str(), q, t);
                 constr_expr = implies(in_queues[q]->deq_cnt(t) == 0 && mk_or(non_empty),
                                       !last_served_queue_[q][t + 1]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
-                snprintf(constr_name,100, "%s_lsq_%d_at_%d_stays_same", id.c_str(), q, t);
+                snprintf(constr_name, 100, "%s_lsq_%d_at_%d_stays_same", id.c_str(), q, t);
                 constr_expr = implies(mk_and(all_empty),
                                       last_served_queue_[q][t + 1] == last_served_queue_[q][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -128,7 +128,7 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
 
         // Make sure nothing else gets pushed to the output queue
         for (unsigned int i = 1; i < outq->max_enq(); i++) {
-            snprintf(constr_name,100, "%s_only_one_output_%d_%d", id.c_str(), i, t);
+            snprintf(constr_name, 100, "%s_only_one_output_%d_%d", id.c_str(), i, t);
             expr constr_expr = outq->enqs(i)[t] == net_ctx.null_pkt();
             constr_map.insert(named_constr(constr_name, constr_expr));
         }

--- a/src/qms/rr_qm.cpp
+++ b/src/qms/rr_qm.cpp
@@ -22,7 +22,7 @@ void RRQM::add_proc_vars(NetContext& net_ctx) {
     for (unsigned int q = 0; q < in_queues.size(); q++) {
         for (unsigned int t = 0; t < total_time; t++) {
             char vname[100];
-            sprintf(vname, "%s_last_served_queue[%d][%d]", id.c_str(), q, t);
+            snprintf(vname,100, "%s_last_served_queue[%d][%d]", id.c_str(), q, t);
             last_served_queue_[q].push_back(net_ctx.bool_const(vname));
         }
     }
@@ -35,11 +35,11 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
 
 
     for (unsigned int q = 0; q < in_queues.size() - 1; q++) {
-        sprintf(constr_name, "%s_%d_not_lsq_at_0", id.c_str(), q);
+        snprintf(constr_name,100, "%s_%d_not_lsq_at_0", id.c_str(), q);
         expr constr_expr = !last_served_queue_[q][0];
         constr_map.insert(named_constr(constr_name, constr_expr));
     }
-    sprintf(constr_name, "%s_%d_lsq_at_0", id.c_str(), (unsigned int) in_queues.size() - 1);
+    snprintf(constr_name,100, "%s_%d_lsq_at_0", id.c_str(), (unsigned int) in_queues.size() - 1);
     expr constr_expr = last_served_queue_[in_queues.size() - 1][0];
     constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -52,7 +52,7 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
 
             unsigned int q = (h + 1) % in_queue_cnt;
             expr not_empty = net_ctx.pkt2val(in_queues[q]->elem(0)[t]);
-            sprintf(constr_name, "%s_head_%d_deq_cnt_%d_%d", id.c_str(), h, q, t);
+            snprintf(constr_name,100, "%s_head_%d_deq_cnt_%d_%d", id.c_str(), h, q, t);
             constr_expr = implies(last_served_queue_[h][t],
                                   in_queues[q]->deq_cnt(t) ==
                                       ite(not_empty, net_ctx.int_val(1), net_ctx.int_val(0)));
@@ -65,7 +65,7 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
                 q = (h + i) % in_queue_cnt;
 
                 not_empty = net_ctx.pkt2val(in_queues[q]->elem(0)[t]);
-                sprintf(constr_name, "%s_head_%d_deq_cnt_%d_%d", id.c_str(), h, q, t);
+                snprintf(constr_name,100, "%s_head_%d_deq_cnt_%d_%d", id.c_str(), h, q, t);
                 constr_expr = implies(last_served_queue_[h][t],
                                       in_queues[q]->deq_cnt(t) == ite(prev_empty && not_empty,
                                                                       net_ctx.int_val(1),
@@ -79,7 +79,7 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
         // Push to output queue accordingly
         Queue* outq = out_queues[0];
         for (unsigned int q = 0; q < in_queue_cnt; q++) {
-            sprintf(constr_name, "%s_output_from_%d_%d", id.c_str(), q, t);
+            snprintf(constr_name,100, "%s_output_from_%d_%d", id.c_str(), q, t);
             constr_expr = implies(in_queues[q]->deq_cnt(t) == 1,
                                   outq->enqs(0)[t] == in_queues[q]->elem(0)[t]);
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -92,23 +92,23 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
             all_empty.push_back(!net_ctx.pkt2val(in_queues[q]->elem(0)[t]));
             non_empty.push_back(net_ctx.pkt2val(in_queues[q]->elem(0)[t]));
         }
-        sprintf(constr_name, "%s_all_empty_input_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_all_empty_input_%d", id.c_str(), t);
         constr_expr = implies(mk_and(all_empty), outq->enqs(0)[t] == net_ctx.null_pkt());
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // Update head
         if (t != total_time - 1) {
             for (unsigned int q = 0; q < in_queue_cnt; q++) {
-                sprintf(constr_name, "%s_lsq_%d_at_%d_is_one", id.c_str(), q, t);
+                snprintf(constr_name,100, "%s_lsq_%d_at_%d_is_one", id.c_str(), q, t);
                 constr_expr = implies(in_queues[q]->deq_cnt(t) > 0, last_served_queue_[q][t + 1]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
-                sprintf(constr_name, "%s_lsq_%d_at_%d_is_zero", id.c_str(), q, t);
+                snprintf(constr_name,100, "%s_lsq_%d_at_%d_is_zero", id.c_str(), q, t);
                 constr_expr = implies(in_queues[q]->deq_cnt(t) == 0 && mk_or(non_empty),
                                       !last_served_queue_[q][t + 1]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
-                sprintf(constr_name, "%s_lsq_%d_at_%d_stays_same", id.c_str(), q, t);
+                snprintf(constr_name,100, "%s_lsq_%d_at_%d_stays_same", id.c_str(), q, t);
                 constr_expr = implies(mk_and(all_empty),
                                       last_served_queue_[q][t + 1] == last_served_queue_[q][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -117,7 +117,7 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
             // TODO: Seems redundant but the solver sometimes likes it
             //       and sometimes not smh
             //            for (unsigned int q = 0; q < in_queues.size(); q++){
-            //                sprintf(constr_name, "%s_lsq[%d]_same_%d", id.c_str(), q, t);
+            //                snprintf(constr_name,100, "%s_lsq[%d]_same_%d", id.c_str(), q, t);
             //                constr_expr = implies(mk_and(all_empty),
             //                                      last_served_queue_[q][t + 1] ==
             //                                      last_served_queue_[q][t]);
@@ -128,7 +128,7 @@ void RRQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
 
         // Make sure nothing else gets pushed to the output queue
         for (unsigned int i = 1; i < outq->max_enq(); i++) {
-            sprintf(constr_name, "%s_only_one_output_%d_%d", id.c_str(), i, t);
+            snprintf(constr_name,100, "%s_only_one_output_%d_%d", id.c_str(), i, t);
             expr constr_expr = outq->enqs(i)[t] == net_ctx.null_pkt();
             constr_map.insert(named_constr(constr_name, constr_expr));
         }

--- a/src/qms/spine_forwarding_qm.cpp
+++ b/src/qms/spine_forwarding_qm.cpp
@@ -43,7 +43,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
         expr pkt_dst = net_ctx.pkt2meta1(in_pkt);
 
         // Set deq_cnt for input queue
-        snprintf(constr_name,100, "%s_in_queue_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_in_queue_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
         expr constr_expr = implies(pkt_val, in_queue->deq_cnt(t) == 1) &&
                            implies(!pkt_val, in_queue->deq_cnt(t) == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
@@ -53,13 +53,14 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
             unsigned int dst_port = dst / servers_per_leaf;
             if (output_voq_map.find(dst_port) == output_voq_map.end()) continue;
             unsigned int voq_ind = output_voq_map[dst_port];
-            snprintf(constr_name,100,
-                    "%s_forward_dst_%d_to_port%d(q%d)_at_%d",
-                    id.c_str(),
-                    dst,
-                    dst_port,
-                    voq_ind,
-                    t);
+            snprintf(constr_name,
+                     100,
+                     "%s_forward_dst_%d_to_port%d(q%d)_at_%d",
+                     id.c_str(),
+                     dst,
+                     dst_port,
+                     voq_ind,
+                     t);
             constr_expr = implies(pkt_val && pkt_dst == (int) dst,
                                   out_queues[voq_ind]->enqs(0)[t] == in_pkt);
             constr_map.insert(named_constr(constr_name, constr_expr));
@@ -69,7 +70,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
         for (unsigned int i = 0; i < leaf_cnt; i++) {
             if (output_voq_map.find(i) == output_voq_map.end()) continue;
             unsigned int voq_ind = output_voq_map[i];
-            snprintf(constr_name,100, "%s_no_match_port%d(q%d)_at_%d", id.c_str(), i, voq_ind, t);
+            snprintf(constr_name, 100, "%s_no_match_port%d(q%d)_at_%d", id.c_str(), i, voq_ind, t);
             constr_expr = implies(pkt_dst < (int) (i * servers_per_leaf) ||
                                       pkt_dst >= (int) ((i + 1) * servers_per_leaf),
                                   out_queues[voq_ind]->enqs(0)[t] == net_ctx.null_pkt());
@@ -84,12 +85,13 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
-                snprintf(constr_name,100,
-                        "%s_flow_meta_bounds_input_queue[%d][%d][%d]",
-                        id.c_str(),
-                        q,
-                        p,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_flow_meta_bounds_input_queue[%d][%d][%d]",
+                         id.c_str(),
+                         q,
+                         p,
+                         t);
                 constr_expr = implies(pkt_val, pkt_meta == (int) spine_id);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -102,12 +104,13 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
-                snprintf(constr_name,100,
-                        "%s_flow_meta_bounds_output_queue[%d][%d][%d]",
-                        id.c_str(),
-                        q,
-                        p,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_flow_meta_bounds_output_queue[%d][%d][%d]",
+                         id.c_str(),
+                         q,
+                         p,
+                         t);
                 constr_expr = implies(pkt_val, pkt_meta == (int) spine_id);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -116,7 +119,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
         // Don't enqueue into any port if packet is invalid
 
         for (unsigned int i = 0; i < out_queue_cnt(); i++) {
-            snprintf(constr_name,100, "%s_invalid_pkt_port_%d_at_%d", id.c_str(), i, t);
+            snprintf(constr_name, 100, "%s_invalid_pkt_port_%d_at_%d", id.c_str(), i, t);
             constr_expr = implies(!pkt_val, out_queues[i]->enqs(0)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -124,7 +127,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
         // Make sure nothing else gets pushed to the output queue
         for (unsigned int i = 0; i < out_queue_cnt(); i++) {
             for (unsigned int e = 1; e < out_queues[i]->max_enq(); e++) {
-                snprintf(constr_name,100, "%s_out_%d_elem[%d][%d]_is_null", id.c_str(), i, e, t);
+                snprintf(constr_name, 100, "%s_out_%d_elem[%d][%d]_is_null", id.c_str(), i, e, t);
                 expr constr_expr = out_queues[i]->enqs(e)[t] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -149,8 +152,8 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
                 expr pkt = queue->enqs(e)[t];
                 expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
-                expr constr_expr = meta3 <= (int) t && meta3 >= 0;
+                snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e,
+        t); expr constr_expr = meta3 <= (int) t && meta3 >= 0;
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
         }

--- a/src/qms/spine_forwarding_qm.cpp
+++ b/src/qms/spine_forwarding_qm.cpp
@@ -43,7 +43,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
         expr pkt_dst = net_ctx.pkt2meta1(in_pkt);
 
         // Set deq_cnt for input queue
-        sprintf(constr_name, "%s_in_queue_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_in_queue_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
         expr constr_expr = implies(pkt_val, in_queue->deq_cnt(t) == 1) &&
                            implies(!pkt_val, in_queue->deq_cnt(t) == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
@@ -53,7 +53,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
             unsigned int dst_port = dst / servers_per_leaf;
             if (output_voq_map.find(dst_port) == output_voq_map.end()) continue;
             unsigned int voq_ind = output_voq_map[dst_port];
-            sprintf(constr_name,
+            snprintf(constr_name,100,
                     "%s_forward_dst_%d_to_port%d(q%d)_at_%d",
                     id.c_str(),
                     dst,
@@ -69,7 +69,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
         for (unsigned int i = 0; i < leaf_cnt; i++) {
             if (output_voq_map.find(i) == output_voq_map.end()) continue;
             unsigned int voq_ind = output_voq_map[i];
-            sprintf(constr_name, "%s_no_match_port%d(q%d)_at_%d", id.c_str(), i, voq_ind, t);
+            snprintf(constr_name,100, "%s_no_match_port%d(q%d)_at_%d", id.c_str(), i, voq_ind, t);
             constr_expr = implies(pkt_dst < (int) (i * servers_per_leaf) ||
                                       pkt_dst >= (int) ((i + 1) * servers_per_leaf),
                                   out_queues[voq_ind]->enqs(0)[t] == net_ctx.null_pkt());
@@ -84,7 +84,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
-                sprintf(constr_name,
+                snprintf(constr_name,100,
                         "%s_flow_meta_bounds_input_queue[%d][%d][%d]",
                         id.c_str(),
                         q,
@@ -102,7 +102,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta2(pkt);
 
-                sprintf(constr_name,
+                snprintf(constr_name,100,
                         "%s_flow_meta_bounds_output_queue[%d][%d][%d]",
                         id.c_str(),
                         q,
@@ -116,7 +116,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
         // Don't enqueue into any port if packet is invalid
 
         for (unsigned int i = 0; i < out_queue_cnt(); i++) {
-            sprintf(constr_name, "%s_invalid_pkt_port_%d_at_%d", id.c_str(), i, t);
+            snprintf(constr_name,100, "%s_invalid_pkt_port_%d_at_%d", id.c_str(), i, t);
             constr_expr = implies(!pkt_val, out_queues[i]->enqs(0)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -124,7 +124,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
         // Make sure nothing else gets pushed to the output queue
         for (unsigned int i = 0; i < out_queue_cnt(); i++) {
             for (unsigned int e = 1; e < out_queues[i]->max_enq(); e++) {
-                sprintf(constr_name, "%s_out_%d_elem[%d][%d]_is_null", id.c_str(), i, e, t);
+                snprintf(constr_name,100, "%s_out_%d_elem[%d][%d]_is_null", id.c_str(), i, e, t);
                 expr constr_expr = out_queues[i]->enqs(e)[t] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -137,7 +137,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
                 expr pkt = queue->enqs(e)[t];
                 expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                sprintf(constr_name, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
+                snprintf(constr_name,100, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
                 expr constr_expr = meta3 <= (int) t && meta3 >= 0;
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -149,7 +149,7 @@ void SpineForwardingQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
                 expr pkt = queue->enqs(e)[t];
                 expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                sprintf(constr_name, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
+                snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
                 expr constr_expr = meta3 <= (int) t && meta3 >= 0;
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }

--- a/src/qms/switch_xbar_qm.cpp
+++ b/src/qms/switch_xbar_qm.cpp
@@ -84,7 +84,7 @@ void SwitchXBarQM::add_proc_vars(NetContext& net_ctx) {
         for (unsigned int q2 = 0; q2 < input_voq_map[q1].size(); q2++) {
             in_to_out_[q1].push_back(vector<expr>());
             for (unsigned int t = 0; t < total_time; t++) {
-                sprintf(vname, "%s_in_to_out[%d][%d][%d]", id.c_str(), q1, q2, t);
+                snprintf(vname, 100, "%s_in_to_out[%d][%d][%d]", id.c_str(), q1, q2, t);
                 in_to_out_[q1][q2].push_back(net_ctx.bool_const(vname));
             }
         }
@@ -94,7 +94,7 @@ void SwitchXBarQM::add_proc_vars(NetContext& net_ctx) {
         for (unsigned int q2 = 0; q2 < output_voq_map[q1].size(); q2++) {
             out_from_in_[q1].push_back(vector<expr>());
             for (unsigned int t = 0; t < total_time; t++) {
-                sprintf(vname, "%s_out_from_in[%d][%d][%d]", id.c_str(), q1, q2, t);
+                snprintf(vname, 100, "%s_out_from_in[%d][%d][%d]", id.c_str(), q1, q2, t);
                 out_from_in_[q1][q2].push_back(net_ctx.bool_const(vname));
             }
         }
@@ -104,7 +104,7 @@ void SwitchXBarQM::add_proc_vars(NetContext& net_ctx) {
         for (unsigned int q2 = 0; q2 < input_voq_map[q1].size(); q2++) {
             in_prio_head_[q1].push_back(vector<expr>());
             for (unsigned int t = 0; t < total_time; t++) {
-                sprintf(vname, "%s_in_prio_head[%d][%d][%d]", id.c_str(), q1, q2, t);
+                snprintf(vname, 100, "%s_in_prio_head[%d][%d][%d]", id.c_str(), q1, q2, t);
                 in_prio_head_[q1][q2].push_back(net_ctx.bool_const(vname));
             }
         }
@@ -114,7 +114,7 @@ void SwitchXBarQM::add_proc_vars(NetContext& net_ctx) {
         for (unsigned int q2 = 0; q2 < output_voq_map[q1].size(); q2++) {
             out_prio_head_[q1].push_back(vector<expr>());
             for (unsigned int t = 0; t < total_time; t++) {
-                sprintf(vname, "%s_out_prio_head[%d][%d][%d]", id.c_str(), q1, q2, t);
+                snprintf(vname, 100, "%s_out_prio_head[%d][%d][%d]", id.c_str(), q1, q2, t);
                 out_prio_head_[q1][q2].push_back(net_ctx.bool_const(vname));
             }
         }
@@ -131,11 +131,11 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
         // DATA
         /*
         for (unsigned int q = 0; q < port_cnt; q++){
-            sprintf(constr_name, "%s_in_prio_head_port_%d_at_%d", id.c_str(), q, t);
+            snprintf(constr_name,100, "%s_in_prio_head_port_%d_at_%d", id.c_str(), q, t);
             expr constr_expr = in_prio_head_[q][t] >= 0 && in_prio_head_[q][t] < (int)
         input_voq_map[q].size(); constr_map.insert(named_constr(constr_name, constr_expr));
 
-            sprintf(constr_name, "%s_out_prio_head_port_%d_at_%d", id.c_str(), q, t);
+            snprintf(constr_name,100, "%s_out_prio_head_port_%d_at_%d", id.c_str(), q, t);
             constr_expr = out_prio_head_[q][t] >= 0 && out_prio_head_[q][t] < (int)
         output_voq_map[q].size(); constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -156,14 +156,15 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                     }
                 }
 
-                sprintf(constr_name,
-                        "%s_in_and_out_together_%d(q%d)_%d(q%d)_at_%d",
-                        id.c_str(),
-                        i,
-                        i_ind_of_j,
-                        j,
-                        j_ind_of_i,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_in_and_out_together_%d(q%d)_%d(q%d)_at_%d",
+                         id.c_str(),
+                         i,
+                         i_ind_of_j,
+                         j,
+                         j_ind_of_i,
+                         t);
 
                 expr constr_expr = (implies(in_to_out_[i][i_ind_of_j][t],
                                             out_from_in_[j][j_ind_of_i][t]) &&
@@ -224,11 +225,11 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
 
                 expr match_cond = mk_and(cond1) && mk_and(cond2) && cond3;
 
-                sprintf(constr_name, "%s_%d_matches_%d_at_%d", id.c_str(), i, j, t);
+                snprintf(constr_name, 100, "%s_%d_matches_%d_at_%d", id.c_str(), i, j, t);
                 expr constr_expr = implies(match_cond, in_to_out_[i][i_ind_of_j][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
-                sprintf(constr_name, "%s_%d_doesnt_match_%d_at_%d", id.c_str(), i, j, t);
+                snprintf(constr_name, 100, "%s_%d_doesnt_match_%d_at_%d", id.c_str(), i, j, t);
                 constr_expr = implies(!match_cond, !in_to_out_[i][i_ind_of_j][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -244,12 +245,13 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                     if (i_ind_of_j == k) continue;
                     others_zero.push_back(!in_to_out_[i][k][t]);
                 }
-                sprintf(constr_name,
-                        "%s_in_port_%d_matches_only_voq_%d_at_%d",
-                        id.c_str(),
-                        i,
-                        i_ind_of_j,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_in_port_%d_matches_only_voq_%d_at_%d",
+                         id.c_str(),
+                         i,
+                         i_ind_of_j,
+                         t);
                 expr constr_expr = implies(in_to_out_[i][i_ind_of_j][t], mk_and(others_zero));
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -265,12 +267,13 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                     if (j_ind_of_i == k) continue;
                     others_zero.push_back(!out_from_in_[j][k][t]);
                 }
-                sprintf(constr_name,
-                        "%s_out_port_%d_matches_only_voq_%d_at_%d",
-                        id.c_str(),
-                        j,
-                        j_ind_of_i,
-                        t);
+                snprintf(constr_name,
+                         100,
+                         "%s_out_port_%d_matches_only_voq_%d_at_%d",
+                         id.c_str(),
+                         j,
+                         j_ind_of_i,
+                         t);
                 expr constr_expr = implies(out_from_in_[j][j_ind_of_i][t], mk_and(others_zero));
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -285,7 +288,7 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
             for (unsigned int p = 0; p < input_voq_map[i].size(); p++) {
                 all_prios.push_back(in_prio_head_[i][p][t]);
             }
-            sprintf(constr_name, "%s_at_least_one_in_prio_head_[%d]_at_%d", id.c_str(), i, t);
+            snprintf(constr_name, 100, "%s_at_least_one_in_prio_head_[%d]_at_%d", id.c_str(), i, t);
             expr constr_expr = mk_or(all_prios);
             constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -295,8 +298,13 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                     if (p == k) continue;
                     others_zero.push_back(!in_prio_head_[i][k][t]);
                 }
-                sprintf(
-                    constr_name, "%s_only_in_prio_head[%d][%d][%d]_is_one", id.c_str(), i, p, t);
+                snprintf(constr_name,
+                         100,
+                         "%s_only_in_prio_head[%d][%d][%d]_is_one",
+                         id.c_str(),
+                         i,
+                         p,
+                         t);
                 expr constr_expr = implies(in_prio_head_[i][p][t], mk_and(others_zero));
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -311,7 +319,8 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
             for (unsigned int p = 0; p < output_voq_map[i].size(); p++) {
                 all_prios.push_back(out_prio_head_[i][p][t]);
             }
-            sprintf(constr_name, "%s_at_least_one_out_prio_head_[%d]_at_%d", id.c_str(), i, t);
+            snprintf(
+                constr_name, 100, "%s_at_least_one_out_prio_head_[%d]_at_%d", id.c_str(), i, t);
             expr constr_expr = mk_or(all_prios);
             constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -321,8 +330,13 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                     if (p == k) continue;
                     others_zero.push_back(!out_prio_head_[i][k][t]);
                 }
-                sprintf(
-                    constr_name, "%s_only_out_prio_head[%d][%d][%d]_is_one", id.c_str(), i, p, t);
+                snprintf(constr_name,
+                         100,
+                         "%s_only_out_prio_head[%d][%d][%d]_is_one",
+                         id.c_str(),
+                         i,
+                         p,
+                         t);
                 expr constr_expr = implies(out_prio_head_[i][p][t], mk_and(others_zero));
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -336,13 +350,17 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                 // Inputs
 
                 if (input_voq_map[i].size() > 0) {
-                    sprintf(constr_name, "%s_in_prio_head[%d][0][0]_is_one", id.c_str(), i);
+                    snprintf(constr_name, 100, "%s_in_prio_head[%d][0][0]_is_one", id.c_str(), i);
                     expr constr_expr = in_prio_head_[i][0][t];
                     constr_map.insert(named_constr(constr_name, constr_expr));
 
                     for (unsigned int p = 1; p < input_voq_map[i].size(); p++) {
-                        sprintf(
-                            constr_name, "%s_in_prio_head[%d][%d][0]_is_zero", id.c_str(), i, p);
+                        snprintf(constr_name,
+                                 100,
+                                 "%s_in_prio_head[%d][%d][0]_is_zero",
+                                 id.c_str(),
+                                 i,
+                                 p);
                         expr constr_expr = !in_prio_head_[i][p][t];
                         constr_map.insert(named_constr(constr_name, constr_expr));
                     }
@@ -350,13 +368,17 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
 
                 // Outputs
                 if (output_voq_map[i].size() > 0) {
-                    sprintf(constr_name, "%s_out_prio_head[%d][0][0]_is_one", id.c_str(), i);
+                    snprintf(constr_name, 100, "%s_out_prio_head[%d][0][0]_is_one", id.c_str(), i);
                     expr constr_expr = out_prio_head_[i][0][t];
                     constr_map.insert(named_constr(constr_name, constr_expr));
 
                     for (unsigned int p = 1; p < output_voq_map[i].size(); p++) {
-                        sprintf(
-                            constr_name, "%s_out_prio_head[%d][%d][0]_is_zero", id.c_str(), i, p);
+                        snprintf(constr_name,
+                                 100,
+                                 "%s_out_prio_head[%d][%d][0]_is_zero",
+                                 id.c_str(),
+                                 i,
+                                 p);
                         constr_expr = !out_prio_head_[i][p][t];
                         constr_map.insert(named_constr(constr_name, constr_expr));
                     }
@@ -368,12 +390,13 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                 for (unsigned int i_ind_of_j = 0; i_ind_of_j < input_voq_map[i].size();
                      i_ind_of_j++) {
                     // TODO: maybe add something to also set the other ones to zero
-                    sprintf(constr_name,
-                            "%s_update_in_prio_head[%d][%d][%d]_to_one",
-                            id.c_str(),
-                            i,
-                            i_ind_of_j,
-                            t);
+                    snprintf(constr_name,
+                             100,
+                             "%s_update_in_prio_head[%d][%d][%d]_to_one",
+                             id.c_str(),
+                             i,
+                             i_ind_of_j,
+                             t);
                     expr constr_expr = implies(in_to_out_[i][i_ind_of_j][prev_t],
                                                in_prio_head_[i][i_ind_of_j][t]);
                     constr_map.insert(named_constr(constr_name, constr_expr));
@@ -385,12 +408,13 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                 }
                 for (unsigned int i_ind_of_j = 0; i_ind_of_j < input_voq_map[i].size();
                      i_ind_of_j++) {
-                    sprintf(constr_name,
-                            "%s_dont_update_in_prio_head[%d][%d][%d]",
-                            id.c_str(),
-                            i,
-                            i_ind_of_j,
-                            t);
+                    snprintf(constr_name,
+                             100,
+                             "%s_dont_update_in_prio_head[%d][%d][%d]",
+                             id.c_str(),
+                             i,
+                             i_ind_of_j,
+                             t);
                     expr constr_expr = implies(mk_and(all_zero),
                                                in_prio_head_[i][i_ind_of_j][t] ==
                                                    in_prio_head_[i][i_ind_of_j][prev_t]);
@@ -402,12 +426,13 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                 for (unsigned int j_ind_of_i = 0; j_ind_of_i < output_voq_map[j].size();
                      j_ind_of_i++) {
                     // TODO: maybe add something to also set the other ones to zero
-                    sprintf(constr_name,
-                            "%s_update_out_prio_head[%d][%d][%d]",
-                            id.c_str(),
-                            j,
-                            j_ind_of_i,
-                            t);
+                    snprintf(constr_name,
+                             100,
+                             "%s_update_out_prio_head[%d][%d][%d]",
+                             id.c_str(),
+                             j,
+                             j_ind_of_i,
+                             t);
                     expr constr_expr = implies(out_from_in_[j][j_ind_of_i][prev_t],
                                                out_prio_head_[j][j_ind_of_i][t]);
                     constr_map.insert(named_constr(constr_name, constr_expr));
@@ -419,12 +444,13 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                 }
                 for (unsigned int j_ind_of_i = 0; j_ind_of_i < output_voq_map[j].size();
                      j_ind_of_i++) {
-                    sprintf(constr_name,
-                            "%s_dont_update_out_prio_head[%d][%d][%d]",
-                            id.c_str(),
-                            j,
-                            j_ind_of_i,
-                            t);
+                    snprintf(constr_name,
+                             100,
+                             "%s_dont_update_out_prio_head[%d][%d][%d]",
+                             id.c_str(),
+                             j,
+                             j_ind_of_i,
+                             t);
                     expr constr_expr = implies(mk_and(all_zero),
                                                out_prio_head_[j][j_ind_of_i][t] ==
                                                    out_prio_head_[j][j_ind_of_i][prev_t]);
@@ -441,19 +467,19 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                 unsigned int j = voq_output_map[voq_ind];
 
                 // Enqueue the packet
-                sprintf(constr_name, "%s_in_%d_packet_to_out_%d_at_%d", id.c_str(), i, j, t);
+                snprintf(constr_name, 100, "%s_in_%d_packet_to_out_%d_at_%d", id.c_str(), i, j, t);
                 expr constr_expr = implies(in_to_out_[i][i_ind_of_j][t],
                                            out_queues[j]->enqs(0)[t] ==
                                                in_queues[voq_ind]->elem(0)[t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
                 // Set input queues deq_cnt
-                sprintf(constr_name, "%s_in_%d_deq_cnt[%d]_is_one", id.c_str(), voq_ind, t);
+                snprintf(constr_name, 100, "%s_in_%d_deq_cnt[%d]_is_one", id.c_str(), voq_ind, t);
                 constr_expr = implies(in_to_out_[i][i_ind_of_j][t],
                                       in_queues[voq_ind]->deq_cnt(t) == 1);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
-                sprintf(constr_name, "%s_in_%d_deq_cnt[%d]_is_zero", id.c_str(), voq_ind, t);
+                snprintf(constr_name, 100, "%s_in_%d_deq_cnt[%d]_is_zero", id.c_str(), voq_ind, t);
                 constr_expr = implies(!in_to_out_[i][i_ind_of_j][t],
                                       in_queues[voq_ind]->deq_cnt(t) == 0);
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -470,14 +496,14 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
             for (unsigned int k = 0; k < output_voq_map[j].size(); k++) {
                 all_zeros.push_back(!out_from_in_[j][k][t]);
             }
-            sprintf(constr_name, "%s_no_enqs_in_out_%d_at_%d", id.c_str(), j, t);
+            snprintf(constr_name, 100, "%s_no_enqs_in_out_%d_at_%d", id.c_str(), j, t);
             expr constr_expr = implies(mk_and(all_zeros),
                                        out_queues[j]->enqs(0)[t] == net_ctx.null_pkt());
             constr_map.insert(named_constr(constr_name, constr_expr));
 
             // Make sure nothing else gets pushed to the output queue
             for (unsigned int e = 1; e < out_queues[j]->max_enq(); e++) {
-                sprintf(constr_name, "%s_out_%d_elem[%d][%d]_is_null", id.c_str(), j, e, t);
+                snprintf(constr_name, 100, "%s_out_%d_elem[%d][%d]_is_null", id.c_str(), j, e, t);
                 expr constr_expr = out_queues[j]->enqs(e)[t] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -491,7 +517,7 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                 expr pkt = queue->enqs(e)[t];
                 expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                sprintf(constr_name, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
+                snprintf(constr_name,100, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
                 expr constr_expr = meta3 <= (int) t && meta3 >= 0;
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -503,8 +529,8 @@ void SwitchXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_ma
                 expr pkt = queue->enqs(e)[t];
                 expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                sprintf(constr_name, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
-                expr constr_expr = meta3 <= (int) t && meta3 >= 0;
+                snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e,
+        t); expr constr_expr = meta3 <= (int) t && meta3 >= 0;
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
         }
@@ -602,7 +628,7 @@ void LeafXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta1(pkt);
 
-                sprintf(constr_name, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), i, p, t);
+                snprintf(constr_name, 100, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), i, p, t);
                 expr constr_expr = implies(pkt_val, pkt_meta == (int) dst);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -613,7 +639,7 @@ void LeafXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta(pkt);
 
-                sprintf(constr_name, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), i, p, t);
+                snprintf(constr_name,100, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), i, p, t);
                 expr constr_expr = implies(pkt_val, pkt_meta == (int) dst);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -637,7 +663,7 @@ void LeafXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
                     bounds.push_back(pkt_meta != (int) dst);
                 }
 
-                sprintf(constr_name, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), qid, p, t);
+                snprintf(constr_name, 100, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), qid, p, t);
                 expr constr_expr = implies(pkt_val, mk_and(bounds));
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -651,7 +677,7 @@ void LeafXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
                 expr pkt = queue->enqs(e)[t];
                 expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                sprintf(constr_name, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
+                snprintf(constr_name,100, "%s_in_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
                 expr constr_expr = meta3 <= (int) t && meta3 >= 0;
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -663,8 +689,8 @@ void LeafXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
                 expr pkt = queue->enqs(e)[t];
                 expr meta3 = net_ctx.pkt2meta3(pkt);
 
-                sprintf(constr_name, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e, t);
-                expr constr_expr = meta3 <= (int) t && meta3 >= 0;
+                snprintf(constr_name,100, "%s_out_%d_enqs[%d][%d]_meta3_bound", id.c_str(), i, e,
+        t); expr constr_expr = meta3 <= (int) t && meta3 >= 0;
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
         }
@@ -673,7 +699,6 @@ void LeafXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map)
 }
 
 ReducedLeafXBarQM::ReducedLeafXBarQM(cid_t id,
-                                     unsigned int leaf_id,
                                      unsigned int starting_qid,
                                      unsigned int servers_per_leaf,
                                      unsigned int spine_cnt,
@@ -684,7 +709,6 @@ ReducedLeafXBarQM::ReducedLeafXBarQM(cid_t id,
                                      vector<QueueInfo> out_queue_info,
                                      NetContext& net_ctx):
 SwitchXBarQM(id, total_time, voq_input_map, voq_output_map, in_queue_info, out_queue_info, net_ctx),
-leaf_id(leaf_id),
 starting_qid(starting_qid),
 servers_per_leaf(servers_per_leaf),
 spine_cnt(spine_cnt) {
@@ -707,7 +731,7 @@ void ReducedLeafXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta1(pkt);
 
-                sprintf(constr_name, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), i, p, t);
+                snprintf(constr_name, 100, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), i, p, t);
                 expr constr_expr = implies(pkt_val, pkt_meta == (int) dst);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -718,7 +742,7 @@ void ReducedLeafXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
                 expr pkt_val = net_ctx.pkt2val(pkt);
                 expr pkt_meta = net_ctx.pkt2meta(pkt);
 
-                sprintf(constr_name, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), i, p, t);
+                snprintf(constr_name,100, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), i, p, t);
                 expr constr_expr = implies(pkt_val, pkt_meta == (int) dst);
                 constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -741,7 +765,7 @@ void ReducedLeafXBarQM::add_constrs(NetContext& net_ctx, map<string, expr>& cons
                     bounds.push_back(pkt_meta != (int) dst);
                 }
 
-                sprintf(constr_name, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), qid, p, t);
+                snprintf(constr_name, 100, "%s_meta_bounds_outq%d[%d][%d]", id.c_str(), qid, p, t);
                 expr constr_expr = implies(pkt_val, mk_and(bounds));
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -53,7 +53,7 @@ void Queue::sliding_window_vars(NetContext& net_ctx) {
     for (unsigned int p = 0; p < size_; p++) {
         for (unsigned int t = 0; t < total_time; t++) {
             char vname[100];
-            snprintf(vname,100, "%s_tmp_val[%d][%d]", id.c_str(), p, t);
+            snprintf(vname, 100, "%s_tmp_val[%d][%d]", id.c_str(), p, t);
             tmp_val[p].push_back(net_ctx.bool_const(vname));
         }
     }
@@ -64,7 +64,7 @@ void Queue::add_vars(NetContext& net_ctx) {
     for (unsigned int p = 0; p < size_; p++) {
         for (unsigned int t = 0; t < total_time; t++) {
             char vname[100];
-            snprintf(vname,100, "%s_elem[%d][%d]", id.c_str(), p, t);
+            snprintf(vname, 100, "%s_elem[%d][%d]", id.c_str(), p, t);
             elems_[p].push_back(net_ctx.pkt_const(vname));
         }
     }
@@ -73,7 +73,7 @@ void Queue::add_vars(NetContext& net_ctx) {
     for (unsigned int p = 0; p < max_enq_; p++) {
         for (unsigned int t = 0; t < total_time; t++) {
             char vname[100];
-            snprintf(vname,100, "%s_enq[%d][%d]", id.c_str(), p, t);
+            snprintf(vname, 100, "%s_enq[%d][%d]", id.c_str(), p, t);
             enqs_[p].push_back(net_ctx.pkt_const(vname));
         }
     }
@@ -81,14 +81,14 @@ void Queue::add_vars(NetContext& net_ctx) {
     // Number of packets to enqueue
     for (unsigned int t = 0; t < total_time; t++) {
         char vname[100];
-        snprintf(vname,100, "%s_enq_cnt[%d]", id.c_str(), t);
+        snprintf(vname, 100, "%s_enq_cnt[%d]", id.c_str(), t);
         enq_cnt_.push_back(net_ctx.int_const(vname));
     }
 
     // Number of packets to dequeue
     for (unsigned int t = 0; t < total_time; t++) {
         char vname[100];
-        snprintf(vname,100, "%s_deq_cnt[%d]", id.c_str(), t);
+        snprintf(vname, 100, "%s_deq_cnt[%d]", id.c_str(), t);
         deq_cnt_.push_back(net_ctx.int_const(vname));
     }
 
@@ -96,7 +96,7 @@ void Queue::add_vars(NetContext& net_ctx) {
 }
 
 void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
-    char /**/constr_name[100];
+    char /**/ constr_name[100];
 
     // taking care of enqs and deqs
     for (unsigned int t = 0; t < total_time; t++) {
@@ -106,12 +106,14 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
         for (unsigned int p = 0; p < size_; p++) {
             for (unsigned int d = 0; d <= max_deq_; d++) {
                 if (p + d < size_) {
-                    snprintf(constr_name,100, "%s_tmp_val[%d][%d]_small_d_%d", id.c_str(), p, t, d);
+                    snprintf(
+                        constr_name, 100, "%s_tmp_val[%d][%d]_small_d_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(deq_cnt_[t] == (int) d,
                                                tmp_val[p][t] == net_ctx.pkt2val(elems_[p + d][t]));
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 } else {
-                    snprintf(constr_name,100, "%s_tmp_val[%d][%d]_large_d_%d", id.c_str(), p, t, d);
+                    snprintf(
+                        constr_name, 100, "%s_tmp_val[%d][%d]_large_d_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(deq_cnt_[t] == (int) d, !tmp_val[p][t]);
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 }
@@ -121,7 +123,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
         // initially all packet are null
         if (t == 0) {
             for (unsigned int p = 0; p < size_; p++) {
-                snprintf(constr_name,100, "%s[%d]_null_at_0", id.c_str(), p);
+                snprintf(constr_name, 100, "%s[%d]_null_at_0", id.c_str(), p);
                 expr constr_expr = elems_[p][0] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -140,7 +142,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
             for (unsigned int p = 0; p < size_; p++) {
                 unsigned int max_relevant_d = min(max_deq_, size_ - p - 1);
                 for (unsigned int d = 0; d <= max_relevant_d; d++) {
-                    snprintf(constr_name,100, "%s[%d][%d]_shift_forward_%d", id.c_str(), p, t, d);
+                    snprintf(constr_name, 100, "%s[%d][%d]_shift_forward_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(tmp_val[p][prev_t] && deq_cnt_[prev_t] == (int) d,
                                                elems_[p][t] == elems_[p + d][prev_t]);
                     constr_map.insert(named_constr(constr_name, constr_expr));
@@ -150,7 +152,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
             // Sliding window
 
             for (unsigned int i = 0; i < max_enq_; i++) {
-                snprintf(constr_name,100, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), i, t, i);
+                snprintf(constr_name, 100, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), i, t, i);
                 expr constr_expr = implies(!tmp_val[0][prev_t], elems_[i][t] == enqs_[i][prev_t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -159,7 +161,13 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr is_enq_wind = tmp_val[p][prev_t] && !tmp_val[p + 1][prev_t];
                 for (unsigned int i = 1; i <= max_enq_; i++) {
                     if (p + i < size_) {
-                        snprintf(constr_name,100, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), p + i, t, i - 1);
+                        snprintf(constr_name,
+                                 100,
+                                 "%s[%d][%d]_gets_enqs[%d]",
+                                 id.c_str(),
+                                 p + i,
+                                 t,
+                                 i - 1);
                         expr constr_expr = implies(is_enq_wind,
                                                    elems_[p + i][t] == enqs_[i - 1][prev_t]);
                         constr_map.insert(named_constr(constr_name, constr_expr));
@@ -168,7 +176,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
             }
 
             for (unsigned int p = 0; p < size_ - max_enq_; p++) {
-                snprintf(constr_name,100, "%s[%d][%d]_gets_null", id.c_str(), p + max_enq_, t);
+                snprintf(constr_name, 100, "%s[%d][%d]_gets_null", id.c_str(), p + max_enq_, t);
                 expr constr_expr = implies(!tmp_val[p][prev_t],
                                            elems_[p + max_enq_][t] == net_ctx.null_pkt());
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -180,7 +188,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
         for (unsigned int p = 0; p < max_enq_ - 1; p++) {
             expr enq1_val = net_ctx.pkt2val(enqs_[p][t]);
             expr enq2_val = net_ctx.pkt2val(enqs_[p + 1][t]);
-            snprintf(constr_name,100, "%s_no_enq_holes_%d_%d", id.c_str(), p, t);
+            snprintf(constr_name, 100, "%s_no_enq_holes_%d_%d", id.c_str(), p, t);
             expr constr_expr = enq1_val || !enq2_val;
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -194,7 +202,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
             enq_cnt_vec.push_back(implies(net_ctx.pkt2val(enqs_[i][t]), enq_cnt_[t] > (int) i));
             enq_cnt_vec.push_back(implies(!net_ctx.pkt2val(enqs_[i][t]), enq_cnt_[t] <= (int) i));
         }
-        snprintf(constr_name,100, "%s_enq_cnt_bounds[%d]", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_enq_cnt_bounds[%d]", id.c_str(), t);
         expr constr_expr = mk_and(enq_cnt_vec);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -225,12 +233,12 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
         }
         deq_cnt_ub_vec.push_back(deq_cnt_[t] <= (int) max_deq_);
 
-        snprintf(constr_name,100, "%s_deq_cnt_bounds[%d]", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_deq_cnt_bounds[%d]", id.c_str(), t);
         constr_expr = mk_and(deq_cnt_ub_vec);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // deq_cnt should be greater than or equal to zero
-        snprintf(constr_name,100, "%s_deq_cnt_gt_zero[%d]", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_deq_cnt_gt_zero[%d]", id.c_str(), t);
         constr_expr = deq_cnt_[t] >= 0;
         constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -238,7 +246,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
         for (unsigned int p = 0; p < size_ - 1; p++) {
             expr elem1_val = net_ctx.pkt2val(elems_[p][t]);
             expr elem2_val = net_ctx.pkt2val(elems_[p + 1][t]);
-            snprintf(constr_name,100, "%s_no_holes_%d_%d", id.c_str(), p, t);
+            snprintf(constr_name, 100, "%s_no_holes_%d_%d", id.c_str(), p, t);
             constr_expr = elem1_val || !elem2_val;
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -395,13 +403,13 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
             for (unsigned int d = 0; d <= max_deq_; d++) {
                 if (p + d < size_) {
                     snprintf(
-                        constr_name,100, "%s_tmp_val[%d][%d]_small_d_%d", id.c_str(), p, t, d);
+                        constr_name, 100, "%s_tmp_val[%d][%d]_small_d_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(deq_cnt_[t] == (int) d,
                                                tmp_val[p][t] == net_ctx.pkt2val(elems_[p + d][t]));
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 } else {
                     snprintf(
-                        constr_name,100, "%s_tmp_val[%d][%d]_large_d_%d", id.c_str(), p, t, d);
+                        constr_name, 100, "%s_tmp_val[%d][%d]_large_d_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(deq_cnt_[t] == (int) d, !tmp_val[p][t]);
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 }
@@ -412,12 +420,12 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
         // and the rest are null
         if (t == 0) {
             for (unsigned int p = 0; p < max_enq_; p++) {
-                snprintf(constr_name,100, "%s[%d]_is_enqs[%d]", id.c_str(), p, p);
+                snprintf(constr_name, 100, "%s[%d]_is_enqs[%d]", id.c_str(), p, p);
                 expr constr_expr = elems_[p][0] == enqs_[p][0];
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
             for (unsigned int p = max_enq_; p < size_; p++) {
-                snprintf(constr_name,100, "%s[%d]_null_at_0", id.c_str(), p);
+                snprintf(constr_name, 100, "%s[%d]_null_at_0", id.c_str(), p);
                 expr constr_expr = elems_[p][0] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -436,7 +444,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
             for (unsigned int p = 0; p < size_; p++) {
                 unsigned int max_relevant_d = min(max_deq_, size_ - p - 1);
                 for (unsigned int d = 0; d <= max_relevant_d; d++) {
-                    snprintf(constr_name,100, "%s[%d][%d]_shift_forward_%d", id.c_str(), p, t, d);
+                    snprintf(constr_name, 100, "%s[%d][%d]_shift_forward_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(tmp_val[p][prev_t] && deq_cnt_[prev_t] == (int) d,
                                                elems_[p][t] == elems_[p + d][prev_t]);
                     constr_map.insert(named_constr(constr_name, constr_expr));
@@ -446,7 +454,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
             // Sliding window
 
             for (unsigned int i = 0; i < max_enq_; i++) {
-                snprintf(constr_name,100, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), i, t, i);
+                snprintf(constr_name, 100, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), i, t, i);
                 expr constr_expr = implies(!tmp_val[0][prev_t], elems_[i][t] == enqs_[i][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -455,7 +463,13 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
                 expr is_enq_wind = tmp_val[p][prev_t] && !tmp_val[p + 1][prev_t];
                 for (unsigned int i = 1; i <= max_enq_; i++) {
                     if (p + i < size_) {
-                        snprintf( constr_name,100, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), p + i, t, i - 1);
+                        snprintf(constr_name,
+                                 100,
+                                 "%s[%d][%d]_gets_enqs[%d]",
+                                 id.c_str(),
+                                 p + i,
+                                 t,
+                                 i - 1);
                         expr constr_expr = implies(is_enq_wind,
                                                    elems_[p + i][t] == enqs_[i - 1][t]);
                         constr_map.insert(named_constr(constr_name, constr_expr));
@@ -464,7 +478,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
             }
 
             for (unsigned int p = 0; p < size_ - max_enq_; p++) {
-                snprintf(constr_name,100, "%s[%d][%d]_gets_null", id.c_str(), p + max_enq_, t);
+                snprintf(constr_name, 100, "%s[%d][%d]_gets_null", id.c_str(), p + max_enq_, t);
                 expr constr_expr = implies(!tmp_val[p][prev_t],
                                            elems_[p + max_enq_][t] == net_ctx.null_pkt());
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -489,7 +503,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
             enq_cnt_vec.push_back(implies(net_ctx.pkt2val(enqs_[i][t]), enq_cnt_[t] > (int) i));
             enq_cnt_vec.push_back(implies(!net_ctx.pkt2val(enqs_[i][t]), enq_cnt_[t] <= (int) i));
         }
-        snprintf(constr_name,100, "%s_enq_cnt_bounds[%d]", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_enq_cnt_bounds[%d]", id.c_str(), t);
         expr constr_expr = mk_and(enq_cnt_vec);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -520,12 +534,12 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
         }
         deq_cnt_ub_vec.push_back(deq_cnt_[t] <= (int) max_deq_);
 
-        snprintf(constr_name,100, "%s_deq_cnt_bounds[%d]", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_deq_cnt_bounds[%d]", id.c_str(), t);
         constr_expr = mk_and(deq_cnt_ub_vec);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // deq_cnt should be greater than or equal to zero
-        snprintf(constr_name,100, "%s_deq_cnt_gt_zero[%d]", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_deq_cnt_gt_zero[%d]", id.c_str(), t);
         constr_expr = deq_cnt_[t] >= 0;
         constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -533,7 +547,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
         for (unsigned int p = 0; p < size_ - 1; p++) {
             expr elem1_val = net_ctx.pkt2val(elems_[p][t]);
             expr elem2_val = net_ctx.pkt2val(elems_[p + 1][t]);
-            snprintf(constr_name,100, "%s_no_holes_%d_%d", id.c_str(), p, t);
+            snprintf(constr_name, 100, "%s_no_holes_%d_%d", id.c_str(), p, t);
             constr_expr = elem1_val || !elem2_val;
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -558,7 +572,7 @@ void Link::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
     for (unsigned int t = 0; t < total_time; t++) {
 
         // deq_cnt is always one
-        snprintf(constr_name,100, "%s_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
         expr pkt_val = net_ctx.pkt2val(elems_[0][t]);
         expr constr_expr = implies(pkt_val, deq_cnt_[t] == 1) &&
                            implies(!pkt_val, deq_cnt_[t] == 0);
@@ -566,22 +580,22 @@ void Link::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
 
         // move enq to elem
         if (t == 0) {
-            snprintf(constr_name,100, "%s[0]_is_null", id.c_str());
+            snprintf(constr_name, 100, "%s[0]_is_null", id.c_str());
             constr_expr = elems_[0][0] == net_ctx.null_pkt();
             constr_map.insert(named_constr(constr_name, constr_expr));
         } else {
             unsigned int prev_t = t - 1;
-            snprintf(constr_name,100, "%s[0]_is_enqs[0][%d]_at_%d", id.c_str(), (t - 1), t);
+            snprintf(constr_name, 100, "%s[0]_is_enqs[0][%d]_at_%d", id.c_str(), (t - 1), t);
             constr_expr = elems_[0][t] == enqs_[0][prev_t];
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
 
         // set enq_cnt
-        snprintf(constr_name,100, "%s_enq_cnt_is_one_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_enq_cnt_is_one_at_%d", id.c_str(), t);
         constr_expr = implies(net_ctx.pkt2val(enqs_[0][t]), enq_cnt_[t] == 1);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        snprintf(constr_name,100, "%s_enq_cnt_is_zero_at_%d", id.c_str(), t);
+        snprintf(constr_name, 100, "%s_enq_cnt_is_zero_at_%d", id.c_str(), t);
         constr_expr = implies(!net_ctx.pkt2val(enqs_[0][t]), enq_cnt_[t] == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
     }

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -53,7 +53,7 @@ void Queue::sliding_window_vars(NetContext& net_ctx) {
     for (unsigned int p = 0; p < size_; p++) {
         for (unsigned int t = 0; t < total_time; t++) {
             char vname[100];
-            sprintf(vname, "%s_tmp_val[%d][%d]", id.c_str(), p, t);
+            snprintf(vname,100, "%s_tmp_val[%d][%d]", id.c_str(), p, t);
             tmp_val[p].push_back(net_ctx.bool_const(vname));
         }
     }
@@ -64,7 +64,7 @@ void Queue::add_vars(NetContext& net_ctx) {
     for (unsigned int p = 0; p < size_; p++) {
         for (unsigned int t = 0; t < total_time; t++) {
             char vname[100];
-            sprintf(vname, "%s_elem[%d][%d]", id.c_str(), p, t);
+            snprintf(vname,100, "%s_elem[%d][%d]", id.c_str(), p, t);
             elems_[p].push_back(net_ctx.pkt_const(vname));
         }
     }
@@ -73,7 +73,7 @@ void Queue::add_vars(NetContext& net_ctx) {
     for (unsigned int p = 0; p < max_enq_; p++) {
         for (unsigned int t = 0; t < total_time; t++) {
             char vname[100];
-            sprintf(vname, "%s_enq[%d][%d]", id.c_str(), p, t);
+            snprintf(vname,100, "%s_enq[%d][%d]", id.c_str(), p, t);
             enqs_[p].push_back(net_ctx.pkt_const(vname));
         }
     }
@@ -81,14 +81,14 @@ void Queue::add_vars(NetContext& net_ctx) {
     // Number of packets to enqueue
     for (unsigned int t = 0; t < total_time; t++) {
         char vname[100];
-        sprintf(vname, "%s_enq_cnt[%d]", id.c_str(), t);
+        snprintf(vname,100, "%s_enq_cnt[%d]", id.c_str(), t);
         enq_cnt_.push_back(net_ctx.int_const(vname));
     }
 
     // Number of packets to dequeue
     for (unsigned int t = 0; t < total_time; t++) {
         char vname[100];
-        sprintf(vname, "%s_deq_cnt[%d]", id.c_str(), t);
+        snprintf(vname,100, "%s_deq_cnt[%d]", id.c_str(), t);
         deq_cnt_.push_back(net_ctx.int_const(vname));
     }
 
@@ -96,7 +96,7 @@ void Queue::add_vars(NetContext& net_ctx) {
 }
 
 void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
-    char constr_name[100];
+    char /**/constr_name[100];
 
     // taking care of enqs and deqs
     for (unsigned int t = 0; t < total_time; t++) {
@@ -106,12 +106,12 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
         for (unsigned int p = 0; p < size_; p++) {
             for (unsigned int d = 0; d <= max_deq_; d++) {
                 if (p + d < size_) {
-                    sprintf(constr_name, "%s_tmp_val[%d][%d]_small_d_%d", id.c_str(), p, t, d);
+                    snprintf(constr_name,100, "%s_tmp_val[%d][%d]_small_d_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(deq_cnt_[t] == (int) d,
                                                tmp_val[p][t] == net_ctx.pkt2val(elems_[p + d][t]));
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 } else {
-                    sprintf(constr_name, "%s_tmp_val[%d][%d]_large_d_%d", id.c_str(), p, t, d);
+                    snprintf(constr_name,100, "%s_tmp_val[%d][%d]_large_d_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(deq_cnt_[t] == (int) d, !tmp_val[p][t]);
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 }
@@ -121,7 +121,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
         // initially all packet are null
         if (t == 0) {
             for (unsigned int p = 0; p < size_; p++) {
-                sprintf(constr_name, "%s[%d]_null_at_0", id.c_str(), p);
+                snprintf(constr_name,100, "%s[%d]_null_at_0", id.c_str(), p);
                 expr constr_expr = elems_[p][0] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -140,7 +140,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
             for (unsigned int p = 0; p < size_; p++) {
                 unsigned int max_relevant_d = min(max_deq_, size_ - p - 1);
                 for (unsigned int d = 0; d <= max_relevant_d; d++) {
-                    sprintf(constr_name, "%s[%d][%d]_shift_forward_%d", id.c_str(), p, t, d);
+                    snprintf(constr_name,100, "%s[%d][%d]_shift_forward_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(tmp_val[p][prev_t] && deq_cnt_[prev_t] == (int) d,
                                                elems_[p][t] == elems_[p + d][prev_t]);
                     constr_map.insert(named_constr(constr_name, constr_expr));
@@ -150,7 +150,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
             // Sliding window
 
             for (unsigned int i = 0; i < max_enq_; i++) {
-                sprintf(constr_name, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), i, t, i);
+                snprintf(constr_name,100, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), i, t, i);
                 expr constr_expr = implies(!tmp_val[0][prev_t], elems_[i][t] == enqs_[i][prev_t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -159,8 +159,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
                 expr is_enq_wind = tmp_val[p][prev_t] && !tmp_val[p + 1][prev_t];
                 for (unsigned int i = 1; i <= max_enq_; i++) {
                     if (p + i < size_) {
-                        sprintf(
-                            constr_name, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), p + i, t, i - 1);
+                        snprintf(constr_name,100, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), p + i, t, i - 1);
                         expr constr_expr = implies(is_enq_wind,
                                                    elems_[p + i][t] == enqs_[i - 1][prev_t]);
                         constr_map.insert(named_constr(constr_name, constr_expr));
@@ -169,7 +168,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
             }
 
             for (unsigned int p = 0; p < size_ - max_enq_; p++) {
-                sprintf(constr_name, "%s[%d][%d]_gets_null", id.c_str(), p + max_enq_, t);
+                snprintf(constr_name,100, "%s[%d][%d]_gets_null", id.c_str(), p + max_enq_, t);
                 expr constr_expr = implies(!tmp_val[p][prev_t],
                                            elems_[p + max_enq_][t] == net_ctx.null_pkt());
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -181,7 +180,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
         for (unsigned int p = 0; p < max_enq_ - 1; p++) {
             expr enq1_val = net_ctx.pkt2val(enqs_[p][t]);
             expr enq2_val = net_ctx.pkt2val(enqs_[p + 1][t]);
-            sprintf(constr_name, "%s_no_enq_holes_%d_%d", id.c_str(), p, t);
+            snprintf(constr_name,100, "%s_no_enq_holes_%d_%d", id.c_str(), p, t);
             expr constr_expr = enq1_val || !enq2_val;
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -195,24 +194,24 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
             enq_cnt_vec.push_back(implies(net_ctx.pkt2val(enqs_[i][t]), enq_cnt_[t] > (int) i));
             enq_cnt_vec.push_back(implies(!net_ctx.pkt2val(enqs_[i][t]), enq_cnt_[t] <= (int) i));
         }
-        sprintf(constr_name, "%s_enq_cnt_bounds[%d]", id.c_str(), t);
+        snprintf(constr_name,100, "%s_enq_cnt_bounds[%d]", id.c_str(), t);
         expr constr_expr = mk_and(enq_cnt_vec);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         //        for (unsigned int p = 0; p < max_enq_ - 1; p++){
         //            expr enq1_val = net_ctx.pkt2val(enqs_[p][t]);
         //            expr enq2_val = net_ctx.pkt2val(enqs_[p + 1][t]);
-        //            sprintf(constr_name, "%s_enq_cnt[%d]_is_%d", id.c_str(), t, p + 1);
+        //            snprintf(constr_name,100, "%s_enq_cnt[%d]_is_%d", id.c_str(), t, p + 1);
         //            expr constr_expr = implies(enq1_val && !enq2_val,
         //                                       enq_cnt_[t] == (int) p + 1);
         //            constr_map.insert(named_constr(constr_name, constr_expr));
         //        }
-        //        sprintf(constr_name, "%s_enq_cnt[%d]_is_0", id.c_str(), t);
+        //        snprintf(constr_name,100, "%s_enq_cnt[%d]_is_0", id.c_str(), t);
         //        expr constr_expr = implies(!net_ctx.pkt2val(enqs_[0][t]),
         //                                   enq_cnt_[t] == 0);
         //        constr_map.insert(named_constr(constr_name, constr_expr));
         //
-        //        sprintf(constr_name, "%s_enq_cnt[%d]_is_%d", id.c_str(), t, max_enq_);
+        //        snprintf(constr_name,100, "%s_enq_cnt[%d]_is_%d", id.c_str(), t, max_enq_);
         //        constr_expr = implies(net_ctx.pkt2val(enqs_[max_enq_ - 1][t]),
         //                                   enq_cnt_[t] == (int) max_enq_);
         //        constr_map.insert(named_constr(constr_name, constr_expr));
@@ -226,12 +225,12 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
         }
         deq_cnt_ub_vec.push_back(deq_cnt_[t] <= (int) max_deq_);
 
-        sprintf(constr_name, "%s_deq_cnt_bounds[%d]", id.c_str(), t);
+        snprintf(constr_name,100, "%s_deq_cnt_bounds[%d]", id.c_str(), t);
         constr_expr = mk_and(deq_cnt_ub_vec);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // deq_cnt should be greater than or equal to zero
-        sprintf(constr_name, "%s_deq_cnt_gt_zero[%d]", id.c_str(), t);
+        snprintf(constr_name,100, "%s_deq_cnt_gt_zero[%d]", id.c_str(), t);
         constr_expr = deq_cnt_[t] >= 0;
         constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -239,7 +238,7 @@ void Queue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& const
         for (unsigned int p = 0; p < size_ - 1; p++) {
             expr elem1_val = net_ctx.pkt2val(elems_[p][t]);
             expr elem2_val = net_ctx.pkt2val(elems_[p + 1][t]);
-            sprintf(constr_name, "%s_no_holes_%d_%d", id.c_str(), p, t);
+            snprintf(constr_name,100, "%s_no_holes_%d_%d", id.c_str(), p, t);
             constr_expr = elem1_val || !elem2_val;
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -395,12 +394,14 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
         for (unsigned int p = 0; p < size_; p++) {
             for (unsigned int d = 0; d <= max_deq_; d++) {
                 if (p + d < size_) {
-                    sprintf(constr_name, "%s_tmp_val[%d][%d]_small_d_%d", id.c_str(), p, t, d);
+                    snprintf(
+                        constr_name,100, "%s_tmp_val[%d][%d]_small_d_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(deq_cnt_[t] == (int) d,
                                                tmp_val[p][t] == net_ctx.pkt2val(elems_[p + d][t]));
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 } else {
-                    sprintf(constr_name, "%s_tmp_val[%d][%d]_large_d_%d", id.c_str(), p, t, d);
+                    snprintf(
+                        constr_name,100, "%s_tmp_val[%d][%d]_large_d_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(deq_cnt_[t] == (int) d, !tmp_val[p][t]);
                     constr_map.insert(named_constr(constr_name, constr_expr));
                 }
@@ -411,12 +412,12 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
         // and the rest are null
         if (t == 0) {
             for (unsigned int p = 0; p < max_enq_; p++) {
-                sprintf(constr_name, "%s[%d]_is_enqs[%d]", id.c_str(), p, p);
+                snprintf(constr_name,100, "%s[%d]_is_enqs[%d]", id.c_str(), p, p);
                 expr constr_expr = elems_[p][0] == enqs_[p][0];
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
             for (unsigned int p = max_enq_; p < size_; p++) {
-                sprintf(constr_name, "%s[%d]_null_at_0", id.c_str(), p);
+                snprintf(constr_name,100, "%s[%d]_null_at_0", id.c_str(), p);
                 expr constr_expr = elems_[p][0] == net_ctx.null_pkt();
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -435,7 +436,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
             for (unsigned int p = 0; p < size_; p++) {
                 unsigned int max_relevant_d = min(max_deq_, size_ - p - 1);
                 for (unsigned int d = 0; d <= max_relevant_d; d++) {
-                    sprintf(constr_name, "%s[%d][%d]_shift_forward_%d", id.c_str(), p, t, d);
+                    snprintf(constr_name,100, "%s[%d][%d]_shift_forward_%d", id.c_str(), p, t, d);
                     expr constr_expr = implies(tmp_val[p][prev_t] && deq_cnt_[prev_t] == (int) d,
                                                elems_[p][t] == elems_[p + d][prev_t]);
                     constr_map.insert(named_constr(constr_name, constr_expr));
@@ -445,7 +446,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
             // Sliding window
 
             for (unsigned int i = 0; i < max_enq_; i++) {
-                sprintf(constr_name, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), i, t, i);
+                snprintf(constr_name,100, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), i, t, i);
                 expr constr_expr = implies(!tmp_val[0][prev_t], elems_[i][t] == enqs_[i][t]);
                 constr_map.insert(named_constr(constr_name, constr_expr));
             }
@@ -454,8 +455,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
                 expr is_enq_wind = tmp_val[p][prev_t] && !tmp_val[p + 1][prev_t];
                 for (unsigned int i = 1; i <= max_enq_; i++) {
                     if (p + i < size_) {
-                        sprintf(
-                            constr_name, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), p + i, t, i - 1);
+                        snprintf( constr_name,100, "%s[%d][%d]_gets_enqs[%d]", id.c_str(), p + i, t, i - 1);
                         expr constr_expr = implies(is_enq_wind,
                                                    elems_[p + i][t] == enqs_[i - 1][t]);
                         constr_map.insert(named_constr(constr_name, constr_expr));
@@ -464,7 +464,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
             }
 
             for (unsigned int p = 0; p < size_ - max_enq_; p++) {
-                sprintf(constr_name, "%s[%d][%d]_gets_null", id.c_str(), p + max_enq_, t);
+                snprintf(constr_name,100, "%s[%d][%d]_gets_null", id.c_str(), p + max_enq_, t);
                 expr constr_expr = implies(!tmp_val[p][prev_t],
                                            elems_[p + max_enq_][t] == net_ctx.null_pkt());
                 constr_map.insert(named_constr(constr_name, constr_expr));
@@ -475,7 +475,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
         //        for (unsigned int p = 0; p < max_enq_ - 1; p++){
         //            expr enq1_val = net_ctx.pkt2val(enqs_[p][t]);
         //            expr enq2_val = net_ctx.pkt2val(enqs_[p + 1][t]);
-        //            sprintf(constr_name, "%s_no_enq_holes_%d_%d", id.c_str(), p, t);
+        //            snprintf(constr_name,100, "%s_no_enq_holes_%d_%d", id.c_str(), p, t);
         //            expr constr_expr = enq1_val || !enq2_val;
         //            constr_map.insert(named_constr(constr_name, constr_expr));
         //        }
@@ -489,24 +489,24 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
             enq_cnt_vec.push_back(implies(net_ctx.pkt2val(enqs_[i][t]), enq_cnt_[t] > (int) i));
             enq_cnt_vec.push_back(implies(!net_ctx.pkt2val(enqs_[i][t]), enq_cnt_[t] <= (int) i));
         }
-        sprintf(constr_name, "%s_enq_cnt_bounds[%d]", id.c_str(), t);
+        snprintf(constr_name,100, "%s_enq_cnt_bounds[%d]", id.c_str(), t);
         expr constr_expr = mk_and(enq_cnt_vec);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         //        for (unsigned int p = 0; p < max_enq_ - 1; p++){
         //            expr enq1_val = net_ctx.pkt2val(enqs_[p][t]);
         //            expr enq2_val = net_ctx.pkt2val(enqs_[p + 1][t]);
-        //            sprintf(constr_name, "%s_enq_cnt[%d]_is_%d", id.c_str(), t, p + 1);
+        //            snprintf(constr_name,100, "%s_enq_cnt[%d]_is_%d", id.c_str(), t, p + 1);
         //            expr constr_expr = implies(enq1_val && !enq2_val,
         //                                       enq_cnt_[t] == (int) p + 1);
         //            constr_map.insert(named_constr(constr_name, constr_expr));
         //        }
-        //        sprintf(constr_name, "%s_enq_cnt[%d]_is_0", id.c_str(), t);
+        //        snprintf(constr_name,100, "%s_enq_cnt[%d]_is_0", id.c_str(), t);
         //        expr constr_expr = implies(!net_ctx.pkt2val(enqs_[0][t]),
         //                                   enq_cnt_[t] == 0);
         //        constr_map.insert(named_constr(constr_name, constr_expr));
         //
-        //        sprintf(constr_name, "%s_enq_cnt[%d]_is_%d", id.c_str(), t, max_enq_);
+        //        snprintf(constr_name,100, "%s_enq_cnt[%d]_is_%d", id.c_str(), t, max_enq_);
         //        constr_expr = implies(net_ctx.pkt2val(enqs_[max_enq_ - 1][t]),
         //                                   enq_cnt_[t] == (int) max_enq_);
         //        constr_map.insert(named_constr(constr_name, constr_expr));
@@ -520,12 +520,12 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
         }
         deq_cnt_ub_vec.push_back(deq_cnt_[t] <= (int) max_deq_);
 
-        sprintf(constr_name, "%s_deq_cnt_bounds[%d]", id.c_str(), t);
+        snprintf(constr_name,100, "%s_deq_cnt_bounds[%d]", id.c_str(), t);
         constr_expr = mk_and(deq_cnt_ub_vec);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
         // deq_cnt should be greater than or equal to zero
-        sprintf(constr_name, "%s_deq_cnt_gt_zero[%d]", id.c_str(), t);
+        snprintf(constr_name,100, "%s_deq_cnt_gt_zero[%d]", id.c_str(), t);
         constr_expr = deq_cnt_[t] >= 0;
         constr_map.insert(named_constr(constr_name, constr_expr));
 
@@ -533,7 +533,7 @@ void ImmQueue::sliding_window_constrs(NetContext& net_ctx, map<string, expr>& co
         for (unsigned int p = 0; p < size_ - 1; p++) {
             expr elem1_val = net_ctx.pkt2val(elems_[p][t]);
             expr elem2_val = net_ctx.pkt2val(elems_[p + 1][t]);
-            sprintf(constr_name, "%s_no_holes_%d_%d", id.c_str(), p, t);
+            snprintf(constr_name,100, "%s_no_holes_%d_%d", id.c_str(), p, t);
             constr_expr = elem1_val || !elem2_val;
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
@@ -558,7 +558,7 @@ void Link::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
     for (unsigned int t = 0; t < total_time; t++) {
 
         // deq_cnt is always one
-        sprintf(constr_name, "%s_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_deq_cnt_is_zero_or_one_at_%d", id.c_str(), t);
         expr pkt_val = net_ctx.pkt2val(elems_[0][t]);
         expr constr_expr = implies(pkt_val, deq_cnt_[t] == 1) &&
                            implies(!pkt_val, deq_cnt_[t] == 0);
@@ -566,22 +566,22 @@ void Link::add_constrs(NetContext& net_ctx, map<string, expr>& constr_map) {
 
         // move enq to elem
         if (t == 0) {
-            sprintf(constr_name, "%s[0]_is_null", id.c_str());
+            snprintf(constr_name,100, "%s[0]_is_null", id.c_str());
             constr_expr = elems_[0][0] == net_ctx.null_pkt();
             constr_map.insert(named_constr(constr_name, constr_expr));
         } else {
             unsigned int prev_t = t - 1;
-            sprintf(constr_name, "%s[0]_is_enqs[0][%d]_at_%d", id.c_str(), (t - 1), t);
+            snprintf(constr_name,100, "%s[0]_is_enqs[0][%d]_at_%d", id.c_str(), (t - 1), t);
             constr_expr = elems_[0][t] == enqs_[0][prev_t];
             constr_map.insert(named_constr(constr_name, constr_expr));
         }
 
         // set enq_cnt
-        sprintf(constr_name, "%s_enq_cnt_is_one_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_enq_cnt_is_one_at_%d", id.c_str(), t);
         constr_expr = implies(net_ctx.pkt2val(enqs_[0][t]), enq_cnt_[t] == 1);
         constr_map.insert(named_constr(constr_name, constr_expr));
 
-        sprintf(constr_name, "%s_enq_cnt_is_zero_at_%d", id.c_str(), t);
+        snprintf(constr_name,100, "%s_enq_cnt_is_zero_at_%d", id.c_str(), t);
         constr_expr = implies(!net_ctx.pkt2val(enqs_[0][t]), enq_cnt_[t] == 0);
         constr_map.insert(named_constr(constr_name, constr_expr));
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -796,7 +796,6 @@ void Search::pick_neighbors(Workload wl, vector<Workload>& neighbors) {
                             new_neighbors++;
                         }
                     }
-
                 }
             }
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -778,7 +778,6 @@ void Search::pick_neighbors(Workload wl, vector<Workload>& neighbors) {
             unsigned int new_neighbors = 0;
             for (unsigned int tries = 0; tries <= 5 && new_neighbors == 0; tries++) {
                 set<TimedSpec> wl_specs = wl.get_all_specs();
-                unsigned int ind = 0;
                 for (set<TimedSpec>::iterator it = wl_specs.begin(); it != wl_specs.end(); it++) {
                     TimedSpec to_modify = *it;
 
@@ -798,7 +797,6 @@ void Search::pick_neighbors(Workload wl, vector<Workload>& neighbors) {
                         }
                     }
 
-                    ind++;
                 }
             }
         }

--- a/src/spec_factory.cpp
+++ b/src/spec_factory.cpp
@@ -15,8 +15,7 @@
 
 #include "util.hpp"
 
-SpecFactory::SpecFactory(SharedConfig* shared_config):
-dists(shared_config->get_dists()) {
+SpecFactory::SpecFactory(SharedConfig* shared_config): dists(shared_config->get_dists()) {
     total_time = shared_config->get_total_time();
     in_queue_cnt = shared_config->get_in_queue_cnt();
     target_queues = shared_config->get_target_queues();

--- a/src/spec_factory.cpp
+++ b/src/spec_factory.cpp
@@ -16,7 +16,6 @@
 #include "util.hpp"
 
 SpecFactory::SpecFactory(SharedConfig* shared_config):
-shared_config(shared_config),
 dists(shared_config->get_dists()) {
     total_time = shared_config->get_total_time();
     in_queue_cnt = shared_config->get_in_queue_cnt();

--- a/src/workload.cpp
+++ b/src/workload.cpp
@@ -1192,9 +1192,7 @@ void Workload::normalize(time_range_t time_range) {
     bool changed = true;
     vector<Comp> new_comps;
 
-    unsigned int round = 0;
     while (changed) {
-        round++;
 
         changed = false;
         new_comps.clear();


### PR DESCRIPTION
- Deleted unused variables
- Replaced `sprintf` with `snprintf`